### PR TITLE
type web handler objects (`Request`, `Response`, `RouteFn`, `FetchEvent`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edge-runtime/node-utils": "^2.2.2",
         "@edge-runtime/primitives": "^4.0.5",
         "make-vfs": "^1.1.0",
-        "next-route-matcher": "^1.0.1",
+        "next-route-matcher": "^1.0.2",
         "redaxios": "^0.5.1",
         "yargs": "^17.7.2",
         "zod": "^3.22.4"
@@ -2424,9 +2424,9 @@
       }
     },
     "node_modules/next-route-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/next-route-matcher/-/next-route-matcher-1.0.1.tgz",
-      "integrity": "sha512-6jshsNPWn2a7v5rhwEt+Bn2T7jNnzAwZs9XpDn/K4YL6akjmNV4G0g2faewSMtYJgYBif7uH8GeW6h8exOUGBQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/next-route-matcher/-/next-route-matcher-1.0.2.tgz",
+      "integrity": "sha512-Pp6aT3AShR1NWTyLImP+svGolPWtpxBgN1F0sLnUP6GA7IzLjYSqNFcWiZR9rq5YH6f1ahZw4cKeQ9RED0WNlg=="
     },
     "node_modules/nofilter": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@edge-runtime/node-utils": "^2.2.2",
     "@edge-runtime/primitives": "^4.0.5",
     "make-vfs": "^1.1.0",
-    "next-route-matcher": "^1.0.1",
+    "next-route-matcher": "^1.0.2",
     "redaxios": "^0.5.1",
     "yargs": "^17.7.2",
     "zod": "^3.22.4"

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,5 +1,6 @@
 import http from "node:http"
 import {once} from "node:events"
+import type { EdgeSpecRequest } from "src/types/web-handler"
 
 export const startServer = (edgeSpec: any, port?: number) => {
   const server = http.createServer(async (req, res) => {
@@ -9,7 +10,7 @@ export const startServer = (edgeSpec: any, port?: number) => {
     const body = Buffer.concat(chunks)
 
     const fullUrl = `http://localhost:${req.socket.localPort}${req.url}`
-    const fetchRequest = new Request(fullUrl, {
+    const fetchRequest: EdgeSpecRequest = new Request(fullUrl, {
       method: req.method,
         headers: Object.entries(req.headers) as [string, string][],
         body: req.method === "GET" ? undefined : body,

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,5 +1,6 @@
 import http from "node:http"
 import { transformToNodeBuilder } from "src/edge-runtime/transform-to-node"
+import { EdgeSpecRequest } from "src/types/web-handler"
 
 export const startServer = (edgeSpec: any, port?: number) => {
   const transformToNode = transformToNodeBuilder({
@@ -7,12 +8,12 @@ export const startServer = (edgeSpec: any, port?: number) => {
   })
 
   const server = http.createServer(
-    transformToNode(async (fetchRequest) => {
+    transformToNode(async (fetchRequest: EdgeSpecRequest) => {
       const { matchedRoute, routeParams } = edgeSpec.routeMatcher(
         new URL(fetchRequest.url).pathname
       )
       const handler = edgeSpec.routeMapWithHandlers[matchedRoute]
-      ;(fetchRequest as Request & { pathParams?: any }).pathParams = routeParams
+      fetchRequest.pathParams = routeParams
 
       const fetchResponse: Response = await handler(fetchRequest)
 

--- a/src/adapters/wintercg-minimal.ts
+++ b/src/adapters/wintercg-minimal.ts
@@ -1,8 +1,16 @@
+import { EdgeSpecFetchEvent } from "src/types/web-handler"
+
 export const addFetchListener = (edgeSpec: any) => {
   addEventListener("fetch", async (event) => {
-    const {matchedRoute, routeParams} = edgeSpec.routeMatcher(new URL(event.request.url).pathname)
+    // TODO: find a better way to cast this
+    const fetchEvent = event as unknown as EdgeSpecFetchEvent
+
+    const { matchedRoute, routeParams } = edgeSpec.routeMatcher(
+      new URL(fetchEvent.request.url).pathname
+    )
     const handler = edgeSpec.routeMapWithHandlers[matchedRoute]
-    event.request.pathParams = routeParams
-    event.respondWith(await handler(event.request))
+    fetchEvent.request.pathParams = routeParams
+
+    fetchEvent.respondWith(await handler(fetchEvent.request))
   })
 }

--- a/src/create-with-edge-spec.ts
+++ b/src/create-with-edge-spec.ts
@@ -1,10 +1,10 @@
-import { RouteFn } from "./create-with-edge-spec.types.js"
 import { SetupParams } from "./types/setup-params.js"
+import { EdgeSpecRouteFn } from "./types/web-handler.js"
 
 export const createWithEdgeSpec = (globalSpec: SetupParams) => {
   return (routeSpec: any) =>
-    (routeFn: RouteFn) =>
-    async (req: Request, _res: Response) => {
+    (routeFn: EdgeSpecRouteFn): EdgeSpecRouteFn =>
+    async (req: Request) => {
       // Identify environment this is being executed in and convert to WinterCG-
       // compatible request
 
@@ -16,7 +16,8 @@ export const createWithEdgeSpec = (globalSpec: SetupParams) => {
       try {
         return await routeFn(req)
       } catch (e) {
-        // Use exception handling middleware to handle failure
+        // TODO: Use exception handling middleware to handle failure
+        throw e
       }
     }
 }

--- a/src/create-with-edge-spec.types.ts
+++ b/src/create-with-edge-spec.types.ts
@@ -1,1 +1,0 @@
-export type RouteFn = (req: Request) => Response | Promise<Response>

--- a/src/serve/create-server-from-route-map.ts
+++ b/src/serve/create-server-from-route-map.ts
@@ -1,4 +1,3 @@
-import * as STD from "src/std/index.js"
 import { createServer } from "node:http"
 import { getRouteMatcher } from "next-route-matcher"
 import { normalizeRouteMap } from "../lib/normalize-route-map.js"
@@ -6,12 +5,10 @@ import {
   type TransformToNodeOptions,
   transformToNodeBuilder,
 } from "src/edge-runtime/transform-to-node.js"
+import { EdgeSpecRouteFn } from "src/types/web-handler.js"
 
 export const createServerFromRouteMap = async (
-  routeMap: Record<
-    string,
-    (req: STD.Request) => STD.Response | Promise<STD.Response>
-  >,
+  routeMap: Record<string, EdgeSpecRouteFn>,
   transformToNodeOptions: TransformToNodeOptions
 ) => {
   const formattedRoutes = normalizeRouteMap(routeMap)
@@ -38,7 +35,7 @@ export const createServerFromRouteMap = async (
           url: req.url,
           transformToNodeOptions,
         })
-        return new STD.Response("Not found", {
+        return new Response("Not found", {
           status: 404,
         })
       }
@@ -46,7 +43,7 @@ export const createServerFromRouteMap = async (
       try {
         return await routeFn(req)
       } catch (e: any) {
-        return new STD.Response(e.toString(), {
+        return new Response(e.toString(), {
           status: 500,
         })
       }

--- a/src/std/Request.d.ts
+++ b/src/std/Request.d.ts
@@ -1,2 +1,0 @@
-import { Request } from "@types/node"
-export { Request }

--- a/src/std/Request.js
+++ b/src/std/Request.js
@@ -1,2 +1,0 @@
-const Request = global.Request
-export { Request }

--- a/src/std/Response.d.ts
+++ b/src/std/Response.d.ts
@@ -1,2 +1,0 @@
-export { Response } from "@types/node"
-export { Response }

--- a/src/std/Response.js
+++ b/src/std/Response.js
@@ -1,2 +1,0 @@
-const Response = global.Response
-export { Response }

--- a/src/std/index.d.ts
+++ b/src/std/index.d.ts
@@ -1,2 +1,0 @@
-export * from "./Request"
-export * from "./Response"

--- a/src/std/index.js
+++ b/src/std/index.js
@@ -1,2 +1,0 @@
-export { Request } from "./Request"
-export { Response } from "./Response"

--- a/src/types/web-handler.ts
+++ b/src/types/web-handler.ts
@@ -15,7 +15,7 @@ export type EdgeSpecResponse = Response
 
 export type EdgeSpecRouteFn = (
   req: EdgeSpecRequest
-) => Promise<EdgeSpecResponse>
+) => EdgeSpecResponse | Promise<EdgeSpecResponse>
 
 export type EdgeSpecFetchEvent = FetchEvent & {
   request: EdgeSpecRequest

--- a/src/types/web-handler.ts
+++ b/src/types/web-handler.ts
@@ -1,0 +1,22 @@
+import type { FetchEvent } from "@edge-runtime/primitives"
+import type { RouteMatcherOutput } from "next-route-matcher"
+
+// TODO: this should be exported directly from next-route-matcher
+type RouteParams = RouteMatcherOutput["routeParams"]
+
+export interface EdgeSpecRequestOptions {
+  pathParams?: RouteParams
+}
+
+export type WithEdgeSpecRequestOptions<T> = T & EdgeSpecRequestOptions
+
+export type EdgeSpecRequest = WithEdgeSpecRequestOptions<Request>
+export type EdgeSpecResponse = Response
+
+export type EdgeSpecRouteFn = (
+  req: EdgeSpecRequest
+) => Promise<EdgeSpecResponse>
+
+export type EdgeSpecFetchEvent = FetchEvent & {
+  request: EdgeSpecRequest
+}

--- a/tests/endpoints/basic-01.test.ts
+++ b/tests/endpoints/basic-01.test.ts
@@ -1,9 +1,8 @@
 import test from "ava"
-import { Response } from "src/std/Response.js"
 import { getTestRoute } from "../fixtures/get-test-route.js"
 
 test("basic-01", async (t) => {
-  const { axios, serverUrl } = await getTestRoute(t, {
+  const { axios } = await getTestRoute(t, {
     globalSpec: {},
     routeSpec: {
       auth: "none",
@@ -14,7 +13,7 @@ test("basic-01", async (t) => {
       return new Response(
         JSON.stringify({
           ok: true,
-        }),
+        })
       )
     },
   })

--- a/tests/endpoints/json-body-01.test.ts
+++ b/tests/endpoints/json-body-01.test.ts
@@ -1,5 +1,4 @@
 import test from "ava"
-import { Response } from "src/std/Response.js"
 import { getTestRoute } from "../fixtures/get-test-route.js"
 import { z } from "zod"
 
@@ -20,7 +19,7 @@ test("json-body-01", async (t) => {
         JSON.stringify({
           ok: true,
           jsonBody,
-        }),
+        })
       )
     },
   })

--- a/tests/fixtures/get-test-route.ts
+++ b/tests/fixtures/get-test-route.ts
@@ -1,10 +1,9 @@
-import * as STD from "src/std/index.js"
 import { createWithEdgeSpec } from "src/create-with-edge-spec.js"
 import type { AxiosInstance } from "axios"
-import http from "node:http"
 import getPort from "@ava/get-port"
 import defaultAxios from "redaxios"
 import { createServerFromRouteMap } from "src/serve/create-server-from-route-map.js"
+import { EdgeSpecRouteFn } from "src/types/web-handler"
 
 export const getTestRoute = async (
   t: any,
@@ -12,7 +11,7 @@ export const getTestRoute = async (
     globalSpec: any
     routeSpec: any
     routePath: string
-    routeFn: (req: STD.Request) => any
+    routeFn: EdgeSpecRouteFn
   }
 ): Promise<{ serverUrl: string; axios: AxiosInstance }> => {
   const withRouteSpec = createWithEdgeSpec(opts.globalSpec)

--- a/tests/response-manipulation.test.ts
+++ b/tests/response-manipulation.test.ts
@@ -1,5 +1,4 @@
 import test from "ava"
-import { Response } from "src/std"
 
 test("get json from response", async (t) => {
   const res = new Response(JSON.stringify({ ok: true }))


### PR DESCRIPTION
Adds type handlers for "web handler" objects in `types/web-handler.ts`. This fixes the build errors 👍 

I also removed everything under `std` for now. I understand the idea there, since the wintercg spec can shift from the node.js one, however a bunch of the codebase wasn't importing from it anyway. I think we should find a better way to enforce usage through "std" if we're going to have it there.

Fixes #15 