### PR TITLE
type adapters, bundled route configuration

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,8 +1,9 @@
 import http from "node:http"
 import { transformToNodeBuilder } from "src/edge-runtime/transform-to-node"
+import { EdgeSpecAdapter } from "src/types/edge-spec"
 import { EdgeSpecRequest } from "src/types/web-handler"
 
-export const startServer = (edgeSpec: any, port?: number) => {
+export const startServer: EdgeSpecAdapter = (edgeSpec, port) => {
   const transformToNode = transformToNodeBuilder({
     defaultOrigin: `http://localhost${port ? `:${port}` : ""}`,
   })

--- a/src/adapters/wintercg-minimal.ts
+++ b/src/adapters/wintercg-minimal.ts
@@ -1,6 +1,7 @@
+import { EdgeSpecAdapter } from "src/types/edge-spec"
 import { EdgeSpecFetchEvent } from "src/types/web-handler"
 
-export const addFetchListener = (edgeSpec: any) => {
+export const addFetchListener: EdgeSpecAdapter = (edgeSpec) => {
   addEventListener("fetch", async (event) => {
     // TODO: find a better way to cast this
     const fetchEvent = event as unknown as EdgeSpecFetchEvent

--- a/src/types/edge-spec.ts
+++ b/src/types/edge-spec.ts
@@ -1,0 +1,18 @@
+import type { EdgeSpecRouteFn, EdgeSpecRouteParams } from "./web-handler"
+
+export type EdgeSpecRouteMatcher = (pathname: string) => {
+  matchedRoute: string
+  routeParams: EdgeSpecRouteParams
+}
+
+export interface EdgeSpec {
+  routeMatcher: EdgeSpecRouteMatcher
+  routeMapWithHandlers: {
+    [route: string]: EdgeSpecRouteFn
+  }
+}
+
+export type EdgeSpecAdapter<ReturnValue = void> = (
+  edgeSpec: EdgeSpec,
+  port?: number
+) => ReturnValue

--- a/src/types/web-handler.ts
+++ b/src/types/web-handler.ts
@@ -1,11 +1,10 @@
 import type { FetchEvent } from "@edge-runtime/primitives"
-import type { RouteMatcherOutput } from "next-route-matcher"
 
-// TODO: this should be exported directly from next-route-matcher
-type RouteParams = RouteMatcherOutput["routeParams"]
-
+export type EdgeSpecRouteParams = {
+  [routeParam: string]: string | string[]
+}
 export interface EdgeSpecRequestOptions {
-  pathParams?: RouteParams
+  pathParams?: EdgeSpecRouteParams
 }
 
 export type WithEdgeSpecRequestOptions<T> = T & EdgeSpecRequestOptions


### PR DESCRIPTION
Adds type for edge spec configuration & edge spec adapters. 

I also thought about including typings in the compiled code in `src/bundle/bundle.ts`, but I decided against it - thoughts? @codetheweb 