### PR TITLE
allow calling `request.json()` without error

### DIFF
--- a/src/middleware/with-input-validation.ts
+++ b/src/middleware/with-input-validation.ts
@@ -283,7 +283,7 @@ export const withInputValidation =
 
     if (input.jsonBody || input.commonParams) {
       try {
-        jsonBody = await req.json()
+        jsonBody = await req.clone().json()
       } catch (e: any) {
         throw new InputParsingError("Error while parsing JSON body")
       }
@@ -293,7 +293,7 @@ export const withInputValidation =
 
     if (input.formData) {
       try {
-        multiPartFormData = await req.formData()
+        multiPartFormData = await req.clone().formData()
         multiPartFormData = Object.fromEntries(multiPartFormData.entries())
       } catch (e: any) {
         throw new InputParsingError("Error while parsing form data")
@@ -304,7 +304,7 @@ export const withInputValidation =
 
     if (input.urlEncodedFormData) {
       try {
-        const params = new URLSearchParams(await req.text())
+        const params = new URLSearchParams(await req.clone().text())
         urlEncodedFormData = Object.fromEntries(params.entries())
       } catch (e: any) {
         throw new InputParsingError("Error while parsing url encoded form data")

--- a/tests/middleware/with-input-validation.test.ts
+++ b/tests/middleware/with-input-validation.test.ts
@@ -371,3 +371,34 @@ test("validate route params", async (t) => {
   t.is(status, 200)
   t.is(data.value, 4)
 })
+
+test("allows getting json", async (t) => {
+  const { axios } = await getTestRoute(t, {
+    ...defaultSpecs,
+    routeSpec: {
+      auth: "none",
+      methods: ["POST"],
+      jsonBody: z.object({
+        hello: z.string(),
+      }),
+      jsonResponse: z.object({
+        hello: z.string(),
+      }),
+    },
+    routeFn: async (req) => {
+      return EdgeSpecResponse.json(await req.json())
+    },
+    routePath: "/hello/world",
+  })
+
+  const { data, status } = await axios.post(
+    "/hello/world",
+    { hello: "world" },
+    {
+      validateStatus: () => true,
+    }
+  )
+
+  t.is(status, 200)
+  t.is(data.hello, "world")
+})


### PR DESCRIPTION
We have to clone the request over in the input validation process in order to allow this behavior

cc @seveibar 