### PR TITLE
`routeParams` in middlewares

### DIFF
--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -9,7 +9,12 @@ export type Middleware<
   ResultOptions = object,
   Context = {},
 > = (
-  request: EdgeSpecRequest<RequiredOptions & Partial<ResultOptions>>,
+  request: EdgeSpecRequest<
+    RequiredOptions &
+      Partial<ResultOptions> & {
+        routeParams: Readonly<Record<string, unknown>>
+      }
+  >,
   ctx: Context,
   next: (
     request: EdgeSpecRequest<RequiredOptions & Partial<ResultOptions>>,

--- a/src/types/edge-spec.ts
+++ b/src/types/edge-spec.ts
@@ -4,7 +4,6 @@ import {
   type EdgeSpecRouteFn,
   type EdgeSpecRouteParams,
   EdgeSpecRequest,
-  EdgeSpecInitializationOptions,
 } from "./web-handler.js"
 
 import type { ReadonlyDeep } from "type-fest"
@@ -89,9 +88,7 @@ export function makeRequestAgainstEdgeSpec(
     } else {
       if ((request as any).routeParams) {
         // These are the route params of the parent route hosting the EdgeSpec service
-        const routeParams = (
-          request as unknown as EdgeSpecInitializationOptions
-        ).routeParams
+        const routeParams = (request as unknown as EdgeSpecRequest).routeParams
 
         // If the child service is hosted at /foo/[...path], we want to find the [...path] parameter
         const wildcardRouteParameters = Object.values(routeParams).filter((p) =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,6 @@
 export type {
   EdgeSpecRequest,
   EdgeSpecRequestOptions,
-  WithEdgeSpecRequestOptions,
   HTTPMethods,
   EdgeSpecResponse,
   EdgeSpecJsonResponse,

--- a/src/types/web-handler.ts
+++ b/src/types/web-handler.ts
@@ -19,21 +19,13 @@ export type EdgeSpecRouteParams = {
 
 export type HeadersDescriptor = Headers | HeadersInit
 
-export interface EdgeSpecInitializationOptions {
+export interface EdgeSpecRequestOptions {
   routeParams: EdgeSpecRouteParams
-}
-
-export interface EdgeSpecMiddlewareOptions {
+  edgeSpec: EdgeSpecRouteBundle
   responseDefaults: Response
 }
 
-export interface EdgeSpecRequestOptions extends EdgeSpecMiddlewareOptions {
-  edgeSpec: EdgeSpecRouteBundle
-}
-
-export type WithEdgeSpecRequestOptions<T> = T & EdgeSpecRequestOptions
-
-export type EdgeSpecRequest<T = {}> = WithEdgeSpecRequestOptions<Request> & T
+export type EdgeSpecRequest<T = {}> = EdgeSpecRequestOptions & Request & T
 
 export interface SerializableToResponse {
   /**
@@ -172,7 +164,7 @@ export class EdgeSpecMultiPartFormDataResponse<
 }
 
 export type EdgeSpecRouteFn<
-  RequestOptions = EdgeSpecInitializationOptions,
+  RequestOptions = EdgeSpecRequestOptions,
   ResponseType extends SerializableToResponse | Response = Response,
   Context = ResponseTypeToContext<ResponseType>,
 > = (
@@ -186,8 +178,8 @@ export type EdgeSpecFetchEvent = FetchEvent & {
 
 export function createEdgeSpecRequest(
   request: Request,
-  options: EdgeSpecRequestOptions & EdgeSpecInitializationOptions
-): EdgeSpecRequest<EdgeSpecInitializationOptions> {
+  options: EdgeSpecRequestOptions
+): EdgeSpecRequest {
   return Object.assign(request, options)
 }
 

--- a/tests/route-spec/types.test.ts
+++ b/tests/route-spec/types.test.ts
@@ -291,15 +291,15 @@ test.skip("typed ctx.json()", () => {
 })
 
 test.skip("middlewares have routeParams", () => {
-  const _: Middleware = (next, req) => {
+  const _: Middleware = (req, ctx, next) => {
     expectTypeOf(req.routeParams).toMatchTypeOf<Record<string, unknown>>()
-    return next(req)
+    return next(req, ctx)
   }
 })
 
 test.skip("middlewares have routeParams which can be typed", () => {
-  const _: Middleware<{ routeParams: { fake: string } }> = (next, req) => {
+  const _: Middleware<{ routeParams: { fake: string } }> = (req, ctx, next) => {
     expectTypeOf(req.routeParams.fake).toMatchTypeOf<string>()
-    return next(req)
+    return next(req, ctx)
   }
 })

--- a/tests/route-spec/types.test.ts
+++ b/tests/route-spec/types.test.ts
@@ -289,3 +289,17 @@ test.skip("typed ctx.json()", () => {
     return ctx.json({ id: 1 })
   })({} as any, DEFAULT_CONTEXT)
 })
+
+test.skip("middlewares have routeParams", () => {
+  const _: Middleware = (next, req) => {
+    expectTypeOf(req.routeParams).toMatchTypeOf<Record<string, unknown>>()
+    return next(req)
+  }
+})
+
+test.skip("middlewares have routeParams which can be typed", () => {
+  const _: Middleware<{ routeParams: { fake: string } }> = (next, req) => {
+    expectTypeOf(req.routeParams.fake).toMatchTypeOf<string>()
+    return next(req)
+  }
+})


### PR DESCRIPTION
Allows `routeParams` to show up in middlewares, as `Record<string, unknown>` by default