### PR TITLE
Fix dev server race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "edgespec",
-  "version": "0.0.22",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edgespec",
-      "version": "0.0.22",
+      "version": "0.0.26",
       "license": "ISC",
       "dependencies": {
         "@edge-runtime/node-utils": "^2.2.2",
         "@edge-runtime/primitives": "^4.0.5",
+        "async-mutex": "^0.4.1",
         "bundle-require": "^4.0.2",
         "chalk": "^5.3.0",
         "clipanion": "^4.0.0-rc.3",
@@ -1931,6 +1932,14 @@
       "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/async-sema": {
@@ -5065,9 +5074,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsup": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@edge-runtime/node-utils": "^2.2.2",
     "@edge-runtime/primitives": "^4.0.5",
+    "async-mutex": "^0.4.1",
     "bundle-require": "^4.0.2",
     "chalk": "^5.3.0",
     "clipanion": "^4.0.0-rc.3",

--- a/src/dev/headless/request-handler-controller.ts
+++ b/src/dev/headless/request-handler-controller.ts
@@ -14,9 +14,8 @@ export class RequestHandlerController {
 
   private bundlePathPromise: Promise<string>
 
-  // These mutexes prevent race conditions if there are multiple concurrent .getWinterCGRuntime() or .getNodeHandler() calls
-  private winterCGLoaderMutex = new Mutex()
-  private nodeHandlerLoaderMutex = new Mutex()
+  // This mutex prevents race conditions if there are multiple concurrent .getWinterCGRuntime() or .getNodeHandler() calls
+  private loaderMutex = new Mutex()
 
   constructor(
     private headlessEventEmitter: TypedEmitter<HeadlessBuildEvents>,
@@ -40,7 +39,7 @@ export class RequestHandlerController {
   }
 
   async getWinterCGRuntime() {
-    return this.winterCGLoaderMutex.runExclusive(async () => {
+    return this.loaderMutex.runExclusive(async () => {
       if (this.cachedWinterCGRuntime) {
         return this.cachedWinterCGRuntime
       }
@@ -59,7 +58,7 @@ export class RequestHandlerController {
   }
 
   async getNodeHandler() {
-    return this.nodeHandlerLoaderMutex.runExclusive(async () => {
+    return this.loaderMutex.runExclusive(async () => {
       if (this.cachedNodeHandler) {
         return this.cachedNodeHandler
       }

--- a/src/dev/headless/request-handler-controller.ts
+++ b/src/dev/headless/request-handler-controller.ts
@@ -1,0 +1,127 @@
+import { once } from "node:events"
+import fs from "node:fs/promises"
+import { EdgeRuntime } from "edge-runtime"
+import { Mutex } from "async-mutex"
+import TypedEmitter from "typed-emitter"
+import { handleRequestWithEdgeSpec } from "src/types/edge-spec"
+import { HeadlessBuildEvents } from "./types"
+
+export class RequestHandlerController {
+  private bundlerState: "building" | "idle" = "idle"
+  private cachedWinterCGRuntime?: EdgeRuntime
+  private cachedNodeHandler?: ReturnType<typeof handleRequestWithEdgeSpec>
+  private bundlePathPromise: Promise<string>
+
+  private winterCGLoaderMutex = new Mutex()
+  private nodeHandlerLoaderMutex = new Mutex()
+
+  constructor(
+    private headlessEventEmitter: TypedEmitter<HeadlessBuildEvents>,
+    initialBundlePath?: string
+  ) {
+    headlessEventEmitter.on(
+      "started-building",
+      this.handleStartedBuilding.bind(this)
+    )
+    headlessEventEmitter.on(
+      "finished-building",
+      this.handleFinishedBuilding.bind(this)
+    )
+    this.bundlePathPromise = initialBundlePath
+      ? Promise.resolve(initialBundlePath)
+      : once(headlessEventEmitter, "finished-building").then(
+          ([{ bundlePath }]) => bundlePath
+        )
+  }
+
+  async getWinterCGRuntime() {
+    if (this.cachedWinterCGRuntime) {
+      return this.cachedWinterCGRuntime
+    }
+
+    return this.winterCGLoaderMutex.runExclusive(async () => {
+      return await this.retryIfBundleInvalidedDuringCallback(async () => {
+        const contents = await fs.readFile(
+          await this.bundlePathPromise,
+          "utf-8"
+        )
+        this.cachedWinterCGRuntime = new EdgeRuntime({
+          initialCode: contents,
+        })
+        return this.cachedWinterCGRuntime
+      })
+    })
+  }
+
+  async getNodeHandler() {
+    if (this.cachedNodeHandler) {
+      return this.cachedNodeHandler
+    }
+
+    return this.nodeHandlerLoaderMutex.runExclusive(async () => {
+      return await this.retryIfBundleInvalidedDuringCallback(async () => {
+        // We append the timestamp to the path to bust the cache
+        const edgeSpecModule = await import(
+          `file:${await this.bundlePathPromise}#${Date.now()}`
+        )
+        // If the file is imported as CJS, the default export is nested.
+        // Naming this with .mjs seems to break some on-the-fly transpiling tools downstream.
+        const defaultExport =
+          edgeSpecModule.default.default ?? edgeSpecModule.default
+        this.cachedNodeHandler = handleRequestWithEdgeSpec(defaultExport)
+
+        return this.cachedNodeHandler
+      })
+    })
+  }
+
+  teardown() {
+    this.headlessEventEmitter.off(
+      "started-building",
+      this.handleStartedBuilding
+    )
+    this.headlessEventEmitter.off(
+      "finished-building",
+      this.handleFinishedBuilding
+    )
+  }
+
+  private handleStartedBuilding() {
+    this.bundlerState = "building"
+    this.cachedWinterCGRuntime = undefined
+    this.cachedNodeHandler = undefined
+  }
+
+  private handleFinishedBuilding() {
+    this.bundlerState = "idle"
+  }
+
+  private async retryIfBundleInvalidedDuringCallback<T>(
+    callback: () => T
+  ): Promise<T> {
+    if (this.bundlerState === "building") {
+      await once(this.headlessEventEmitter, "finished-building")
+    }
+
+    let didStartBuildingDuringReload = false
+    let finishedBuildingPromise: Promise<any> | undefined
+    once(this.headlessEventEmitter, "started-building").then(() => {
+      didStartBuildingDuringReload = true
+      finishedBuildingPromise = once(
+        this.headlessEventEmitter,
+        "finished-building"
+      )
+    })
+
+    const result = await callback()
+
+    if (didStartBuildingDuringReload) {
+      await finishedBuildingPromise
+      return await this.retryIfBundleInvalidedDuringCallback(
+        callback.bind(this)
+      )
+    }
+
+    return result
+  }
+}

--- a/src/dev/headless/request-handler-controller.ts
+++ b/src/dev/headless/request-handler-controller.ts
@@ -14,8 +14,8 @@ export class RequestHandlerController {
 
   private bundlePathPromise: Promise<string>
 
-  // This mutex prevents race conditions if there are multiple concurrent .getWinterCGRuntime() or .getNodeHandler() calls
-  private loaderMutex = new Mutex()
+  // This prevents race conditions if there are multiple concurrent .getWinterCGRuntime() or .getNodeHandler() calls
+  private loaderPromiseChain = new Mutex()
 
   constructor(
     private headlessEventEmitter: TypedEmitter<HeadlessBuildEvents>,
@@ -42,7 +42,7 @@ export class RequestHandlerController {
    * You **should not** cache the result of this function. Call it every time you want to use the runtime.
    */
   async getWinterCGRuntime() {
-    return this.loaderMutex.runExclusive(async () => {
+    return this.loaderPromiseChain.runExclusive(async () => {
       if (this.cachedWinterCGRuntime) {
         return this.cachedWinterCGRuntime
       }
@@ -64,7 +64,7 @@ export class RequestHandlerController {
    * You **should not** cache the result of this function. Call it every time you want to use the handler.
    */
   async getNodeHandler() {
-    return this.loaderMutex.runExclusive(async () => {
+    return this.loaderPromiseChain.runExclusive(async () => {
       if (this.cachedNodeHandler) {
         return this.cachedNodeHandler
       }

--- a/src/dev/headless/request-handler-controller.ts
+++ b/src/dev/headless/request-handler-controller.ts
@@ -38,6 +38,9 @@ export class RequestHandlerController {
         )
   }
 
+  /**
+   * You **should not** cache the result of this function. Call it every time you want to use the runtime.
+   */
   async getWinterCGRuntime() {
     return this.loaderMutex.runExclusive(async () => {
       if (this.cachedWinterCGRuntime) {
@@ -57,6 +60,9 @@ export class RequestHandlerController {
     })
   }
 
+  /**
+   * You **should not** cache the result of this function. Call it every time you want to use the handler.
+   */
   async getNodeHandler() {
     return this.loaderMutex.runExclusive(async () => {
       if (this.cachedNodeHandler) {

--- a/src/dev/headless/start-server.ts
+++ b/src/dev/headless/start-server.ts
@@ -1,13 +1,12 @@
-import { once } from "node:events"
+import EventEmitter, { once } from "node:events"
 import { createServer } from "node:http"
 import fs from "node:fs/promises"
 import TypedEmitter from "typed-emitter"
 import { transformToNodeBuilder } from "src/edge-runtime/transform-to-node"
 import { HeadlessBuildEvents } from "./types"
 import { ResolvedEdgeSpecConfig } from "src/config/utils"
-import { EdgeRuntime } from "edge-runtime"
-import { handleRequestWithEdgeSpec } from "src/types/edge-spec"
 import chalk from "chalk"
+import { RequestHandlerController } from "./request-handler-controller"
 
 export interface StartHeadlessDevServerOptions {
   port: number
@@ -27,63 +26,25 @@ export const startHeadlessDevServer = async ({
   headlessEventEmitter,
   initialBundlePath,
 }: StartHeadlessDevServerOptions) => {
-  let runtime: EdgeRuntime
-  let nonWinterCGHandler: ReturnType<typeof handleRequestWithEdgeSpec>
-
-  let bundlePath: string
-  if (initialBundlePath) {
-    bundlePath = initialBundlePath
-  }
-  let shouldReload = true
-  const finishedBuildingListener: HeadlessBuildEvents["finished-building"] = (
-    result
-  ) => {
-    bundlePath = result.bundlePath
-    shouldReload = true
-  }
-  headlessEventEmitter.on("finished-building", finishedBuildingListener)
-
-  const reload = async () => {
-    if (config.emulateWinterCG) {
-      const contents = await fs.readFile(bundlePath, "utf-8")
-      runtime = new EdgeRuntime({
-        initialCode: contents,
-      })
-    } else {
-      // We append the timestamp to the path to bust the cache
-      const edgeSpecModule = await import(`file:${bundlePath}#${Date.now()}`)
-      // If the file is imported as CJS, the default export is nested.
-      // Naming this with .mjs seems to break some on-the-fly transpiling tools downstream.
-      const defaultExport =
-        edgeSpecModule.default.default ?? edgeSpecModule.default
-      nonWinterCGHandler = handleRequestWithEdgeSpec(defaultExport)
-    }
-
-    shouldReload = false
-  }
-
-  // Used to avoid a race condition where the server attempts to process a request before the first build is complete
-  const firstBuildPromise = initialBundlePath
-    ? Promise.resolve()
-    : once(headlessEventEmitter, "finished-building")
+  const controller = new RequestHandlerController(
+    headlessEventEmitter,
+    initialBundlePath
+  )
 
   const server = createServer(
     transformToNodeBuilder({
       defaultOrigin: `http://localhost:${port}`,
     })(async (req) => {
-      await firstBuildPromise
-      if (shouldReload) {
-        await reload()
-      }
-
-      if (config.emulateWinterCG) {
-        const response = await runtime.dispatchFetch(req.url, req)
-        await response.waitUntil()
-        return response
-      }
-
       try {
-        return await nonWinterCGHandler(req)
+        if (config.emulateWinterCG) {
+          const runtime = await controller.getWinterCGRuntime()
+          const response = await runtime.dispatchFetch(req.url, req)
+          await response.waitUntil()
+          return response
+        }
+
+        const nodeHandler = await controller.getNodeHandler()
+        return await nodeHandler(req)
       } catch (error) {
         if (error instanceof Error) {
           process.stderr.write(
@@ -114,7 +75,7 @@ export const startHeadlessDevServer = async ({
       const closePromise = once(server, "close")
       server.close()
       await closePromise
-      headlessEventEmitter.off("finished-building", finishedBuildingListener)
+      controller.teardown()
     },
   }
 }

--- a/src/dev/headless/start-server.ts
+++ b/src/dev/headless/start-server.ts
@@ -1,6 +1,5 @@
-import EventEmitter, { once } from "node:events"
+import { once } from "node:events"
 import { createServer } from "node:http"
-import fs from "node:fs/promises"
 import TypedEmitter from "typed-emitter"
 import { transformToNodeBuilder } from "src/edge-runtime/transform-to-node"
 import { HeadlessBuildEvents } from "./types"


### PR DESCRIPTION
tl;dr: the dev server sometimes read the bundle from the file system before esbuild was finished writing it. This manifested as a flaky test in CI.

The added code looks complex but it turns out there's a lot of race conditions we need to cover.
