### PR TITLE
`ctx` refactor, add typed helpers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,6 +1,6 @@
 # Middleware
 
-Middleware in EdgeSpec follows a similar pattern to other libraries like Express/Fastify/Koa. Middleware receives two parameters: the `next` function and the incoming `req` object. It is expected to always call `next`.
+Middleware in EdgeSpec follows a similar pattern to other libraries like Express/Fastify/Koa. Middleware receives three parameters: the incoming `req` object, the `ctx` context object, and the `next` function. It is expected to always call `next`.
 
 Here's a few example use cases:
 
@@ -11,9 +11,9 @@ Mutate the passed `req` object. For example:
 ```typescript
 import type { Middleware } from "edgespec"
 
-export const exampleMiddleware: Middleware = (next, req) => {
+export const exampleMiddleware: Middleware = (req, ctx, next) => {
   req.foo = "bar"
-  return next(req)
+  return next(req, ctx)
 }
 
 // Later, in a route...
@@ -38,9 +38,9 @@ const baseResponse = new Response(null, {
   },
 })
 
-export const exampleMiddleware: Middleware = (next, req) => {
+export const exampleMiddleware: Middleware = (req, ctx, next) => {
   req.responseDefaults = baseResponse
-  return next(req)
+  return next(req, ctx)
 }
 ```
 
@@ -58,10 +58,10 @@ export const databaseMiddleware: Middleware<
   {
     db: DatabaseClient
   }
-> = async (next, req) => {
+> = async (req, ctx, next) => {
   const db = await connectToDatabase()
   req.db = db
-  return next(req)
+  return next(req, ctx)
 }
 
 export const bearerAuthMiddleware: Middleware<
@@ -73,7 +73,7 @@ export const bearerAuthMiddleware: Middleware<
   {
     is_authenticated: boolean
   }
-> = (next, req) => {
+> = (req, ctx, next) => {
   const authToken = req.headers.get("authorization")?.split("Bearer ")?.[1]
   if (!authToken) {
     // EdgeSpec will attach returned properties to the Request object
@@ -88,7 +88,7 @@ export const bearerAuthMiddleware: Middleware<
 
   req.is_authenticated = Boolean(user)
 
-  return next(req)
+  return next(req, ctx)
 }
 ```
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -17,14 +17,12 @@ export default withEdgeSpec({
   jsonResponse: z.object({
     sum: z.number(),
   }),
-})((req) => {
-  const { a, b } = await req.json()
+})((req, ctx) => {
+  const { a, b } = await req.jsonBody
 
-  return new Response(
-    JSON.stringify({
-      sum: a + b,
-    })
-  )
+  return ctx.json({
+    sum: a + b,
+  })
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edgespec",
-  "version": "0.0.27",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edgespec",
-      "version": "0.0.27",
+      "version": "0.0.31",
       "license": "ISC",
       "dependencies": {
         "@edge-runtime/node-utils": "^2.2.2",

--- a/src/create-with-edge-spec.ts
+++ b/src/create-with-edge-spec.ts
@@ -16,6 +16,7 @@ import { withMethods } from "./middleware/with-methods.js"
 import { withInputValidation } from "./middleware/with-input-validation.js"
 import { withUnhandledExceptionHandling } from "./middleware/with-unhandled-exception-handling.js"
 import { ResponseValidationError } from "./middleware/http-exceptions.js"
+import { DEFAULT_CONTEXT } from "./types/context.js"
 
 export const createWithEdgeSpec = <const GS extends GlobalSpec>(
   globalSpec: GS
@@ -123,7 +124,7 @@ function serializeResponse(
 
 export async function wrapMiddlewares(
   middlewares: MiddlewareChain,
-  routeFn: EdgeSpecRouteFn<any, any>,
+  routeFn: EdgeSpecRouteFn<any, any, any>,
   request: EdgeSpecRequest
 ) {
   return await middlewares.reduceRight(
@@ -132,7 +133,7 @@ export async function wrapMiddlewares(
         return middleware(next, req)
       }
     },
-    async (request: EdgeSpecRequest) => routeFn(request)
+    async (request: EdgeSpecRequest) => routeFn(request, DEFAULT_CONTEXT)
   )(request)
 }
 

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -4,11 +4,17 @@ import type {
   SerializableToResponse,
 } from "../types/web-handler"
 
-export type Middleware<RequiredOptions = {}, ResultOptions = object> = (
+export type Middleware<
+  RequiredOptions = {},
+  ResultOptions = object,
+  Context = {},
+> = (
+  request: EdgeSpecRequest<RequiredOptions & Partial<ResultOptions>>,
+  ctx: Context,
   next: (
-    request: EdgeSpecRequest<RequiredOptions & Partial<ResultOptions>>
-  ) => Promise<Response>,
-  request: EdgeSpecRequest<RequiredOptions & Partial<ResultOptions>>
+    request: EdgeSpecRequest<RequiredOptions & Partial<ResultOptions>>,
+    ctx: Context
+  ) => Promise<Response>
 ) =>
   | Response
   | SerializableToResponse

--- a/src/middleware/with-default-exception-handling.ts
+++ b/src/middleware/with-default-exception-handling.ts
@@ -1,8 +1,12 @@
 import { Middleware } from "src/middleware/types"
 
-export const withDefaultExceptionHandling: Middleware = async (next, req) => {
+export const withDefaultExceptionHandling: Middleware = async (
+  req,
+  ctx,
+  next
+) => {
   try {
-    return await next(req)
+    return await next(req, ctx)
   } catch (e: any) {
     if ("_isHttpException" in e) {
       return Response.json(

--- a/src/middleware/with-input-validation.ts
+++ b/src/middleware/with-input-validation.ts
@@ -231,7 +231,7 @@ export const withInputValidation =
       urlEncodedFormData: z.output<UrlEncodedFormData>
     }
   > =>
-  async (next, req) => {
+  async (req, ctx, next) => {
     const { supportedArrayFormats } = input
 
     if (
@@ -388,5 +388,5 @@ export const withInputValidation =
       throw new InputParsingError("Error while parsing input")
     }
 
-    return next(req)
+    return next(req, ctx)
   }

--- a/src/middleware/with-methods.ts
+++ b/src/middleware/with-methods.ts
@@ -4,10 +4,10 @@ import { MethodNotAllowedError } from "./http-exceptions"
 
 export const withMethods =
   (methods: readonly HTTPMethods[]): Middleware =>
-  (next, req) => {
+  (req, ctx, next) => {
     if (!(methods as string[]).includes(req.method)) {
       throw new MethodNotAllowedError(methods)
     }
 
-    return next(req)
+    return next(req, ctx)
   }

--- a/src/middleware/with-unhandled-exception-handling.ts
+++ b/src/middleware/with-unhandled-exception-handling.ts
@@ -1,8 +1,12 @@
 import { Middleware } from "src/middleware/types"
 
-export const withUnhandledExceptionHandling: Middleware = async (next, req) => {
+export const withUnhandledExceptionHandling: Middleware = async (
+  req,
+  ctx,
+  next
+) => {
   try {
-    return await next(req)
+    return await next(req, ctx)
   } catch (e: any) {
     if ("_isHttpException" in e) {
       console.warn(

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,39 @@
+import {
+  EdgeSpecCustomResponse,
+  EdgeSpecJsonResponse,
+  EdgeSpecMultiPartFormDataResponse,
+  EdgeSpecResponse,
+  SerializableToResponse,
+} from "./web-handler"
+
+export type ResponseTypeToContext<
+  ResponseType extends SerializableToResponse | Response,
+> = Exclude<ResponseType, Response> extends EdgeSpecJsonResponse<infer T>
+  ? {
+      json: typeof EdgeSpecResponse.json<T>
+    }
+  : Exclude<ResponseType, Response> extends EdgeSpecMultiPartFormDataResponse<
+        infer T
+      >
+    ? {
+        multipartFormData: typeof EdgeSpecResponse.multipartFormData<T>
+      }
+    : Exclude<ResponseType, Response> extends EdgeSpecCustomResponse<
+          infer T,
+          infer C
+        >
+      ? {
+          custom: typeof EdgeSpecResponse.custom<T, C>
+        }
+      : {
+          json: typeof EdgeSpecResponse.json<unknown>
+          multipartFormData: typeof EdgeSpecResponse.multipartFormData<
+            Record<string, string>
+          >
+        }
+
+export const DEFAULT_CONTEXT = {
+  json: EdgeSpecResponse.json,
+  multipartFormData: EdgeSpecResponse.multipartFormData,
+  custom: EdgeSpecResponse.custom,
+} as const

--- a/src/types/edge-spec.ts
+++ b/src/types/edge-spec.ts
@@ -9,6 +9,7 @@ import {
 
 import type { ReadonlyDeep } from "type-fest"
 import { wrapMiddlewares } from "src/create-with-edge-spec.js"
+import { DEFAULT_CONTEXT } from "./context.js"
 
 export type EdgeSpecRouteMatcher = (pathname: string) =>
   | {
@@ -121,7 +122,7 @@ export function makeRequestAgainstEdgeSpec(
     })
 
     if (!routeFn) {
-      return await handle404(edgeSpecRequest)
+      return await handle404(edgeSpecRequest, DEFAULT_CONTEXT)
     }
 
     return wrapMiddlewares(options.middleware ?? [], routeFn, edgeSpecRequest)

--- a/src/types/global-spec.ts
+++ b/src/types/global-spec.ts
@@ -13,7 +13,7 @@ export type QueryArrayFormats = readonly QueryArrayFormat[]
 
 export type GlobalSpec = {
   authMiddlewareMap: Record<string, Middleware<any, any>>
-  globalMiddlewares: readonly Middleware<any, any>[]
+  globalMiddlewares: readonly Middleware<unknown, unknown, {}>[]
   globalMiddlewaresAfterAuth?: readonly Middleware<any, any>[]
 
   // These improve OpenAPI generation

--- a/src/types/web-handler.ts
+++ b/src/types/web-handler.ts
@@ -2,6 +2,7 @@ import type { FetchEvent } from "@edge-runtime/primitives"
 import { EdgeSpecRouteBundle } from "./edge-spec"
 import { Primitive } from "type-fest"
 import { z } from "zod"
+import { ResponseTypeToContext } from "./context"
 
 export type HTTPMethods =
   | "GET"
@@ -173,8 +174,10 @@ export class EdgeSpecMultiPartFormDataResponse<
 export type EdgeSpecRouteFn<
   RequestOptions = EdgeSpecInitializationOptions,
   ResponseType extends SerializableToResponse | Response = Response,
+  Context = ResponseTypeToContext<ResponseType>,
 > = (
-  req: EdgeSpecRequest<RequestOptions>
+  req: EdgeSpecRequest<RequestOptions>,
+  ctx: Context
 ) => ResponseType | Promise<ResponseType>
 
 export type EdgeSpecFetchEvent = FetchEvent & {

--- a/tests/middleware-injection/nodejs/middleware-injection.test.ts
+++ b/tests/middleware-injection/nodejs/middleware-injection.test.ts
@@ -1,14 +1,15 @@
 import test from "ava"
-import { Middleware } from "src/middleware"
-import { getTestServer } from "tests/fixtures/get-test-server"
+import { Middleware } from "../../../src/middleware"
+import { getTestServer } from "../../../tests/fixtures/get-test-server"
 
 test("Node.js middleware injection", async (t) => {
   const sampleMiddleware: Middleware<{}, { middlewareType: string }> = (
-    next,
-    req
+    req,
+    ctx,
+    next
   ) => {
     req.middlewareType = "nodejs"
-    return next(req)
+    return next(req, ctx)
   }
 
   const fixture = await getTestServer(t, import.meta.url, {

--- a/tests/middleware-injection/nodejs/with-route-spec.ts
+++ b/tests/middleware-injection/nodejs/with-route-spec.ts
@@ -2,14 +2,15 @@ import { createWithEdgeSpec } from "../../../src"
 import type { Middleware } from "../../../src/middleware"
 
 const sampleMiddleware: Middleware<{}, { middlewareType: string }> = (
-  next,
-  req
+  req,
+  ctx,
+  next
 ) => {
   if (!req.middlewareType) {
     req.middlewareType = "uninjected"
   }
 
-  return next(req)
+  return next(req, ctx)
 }
 
 export const withRouteSpec = createWithEdgeSpec({

--- a/tests/middleware-injection/wintercg/middleware-injection.test.ts
+++ b/tests/middleware-injection/wintercg/middleware-injection.test.ts
@@ -4,11 +4,12 @@ import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("wintercg middleware injection", async (t) => {
   const sampleMiddleware: Middleware<{}, { middlewareType: string }> = (
-    next,
-    req
+    req,
+    ctx,
+    next
   ) => {
     req.middlewareType = "wintercg"
-    return next(req)
+    return next(req, ctx)
   }
 
   const fixture = await getTestServer(t, import.meta.url, {

--- a/tests/middleware-injection/wintercg/with-route-spec.ts
+++ b/tests/middleware-injection/wintercg/with-route-spec.ts
@@ -2,14 +2,15 @@ import { createWithEdgeSpec } from "../../../src"
 import type { Middleware } from "../../../src/middleware"
 
 const sampleMiddleware: Middleware<{}, { middlewareType: string }> = (
-  next,
-  req
+  req,
+  ctx,
+  next
 ) => {
   if (!req.middlewareType) {
     req.middlewareType = "uninjected"
   }
 
-  return next(req)
+  return next(req, ctx)
 }
 
 export const withRouteSpec = createWithEdgeSpec({

--- a/tests/middleware/with-input-validation.test.ts
+++ b/tests/middleware/with-input-validation.test.ts
@@ -12,10 +12,11 @@ const defaultSpecs = {
 
     authMiddlewareMap: {},
     globalMiddlewares: [
-      async (next, req) => {
+      async (req, ctx, next) => {
         try {
-          return await next(req)
+          return await next(req, ctx)
         } catch (e: any) {
+          console.log(e)
           return Response.json(
             { error_type: e.constructor.name },
             { status: 500 }

--- a/tests/route-spec/responses.test.ts
+++ b/tests/route-spec/responses.test.ts
@@ -192,6 +192,44 @@ test("can set headers, status", async (t) => {
   t.deepEqual(response.data, { hello: "world" })
 })
 
+test("can set headers, status w/ context", async (t) => {
+  const { axios } = await getTestRoute(t, {
+    ...defaultSpecs,
+    routeSpec: {
+      auth: "none",
+      methods: ["GET"],
+      multipartFormDataResponse: z.object({
+        hello: z.string(),
+      }),
+    },
+    routeFn: (_, ctx) => {
+      return ctx
+        .json({
+          hello: "world",
+        })
+        .status(201)
+        .header("x-hello", "world")
+        .headers({
+          "x-hello-2": "world2",
+          "x-hello": "world2",
+        })
+    },
+    routePath: "/hello",
+  })
+
+  const response = await axios.get("/hello")
+
+  t.is(response.status, 201)
+  // @ts-expect-error
+  t.is(response.headers.get("content-type"), "application/json")
+  // @ts-expect-error
+  t.is(response.headers.get("x-hello"), "world2")
+  // @ts-expect-error
+  t.is(response.headers.get("x-hello-2"), "world2")
+
+  t.deepEqual(response.data, { hello: "world" })
+})
+
 test("can return custom response types", async (t) => {
   const { axios } = await getTestRoute(t, {
     ...defaultSpecs,

--- a/tests/route-spec/responses.test.ts
+++ b/tests/route-spec/responses.test.ts
@@ -12,9 +12,9 @@ const defaultSpecs = {
 
     authMiddlewareMap: {},
     globalMiddlewares: [
-      async (next, req) => {
+      async (req, ctx, next) => {
         try {
-          return await next(req)
+          return await next(req, ctx)
         } catch (e: any) {
           return EdgeSpecResponse.json(
             { error_type: e.constructor.name },

--- a/tests/route-spec/types.test.ts
+++ b/tests/route-spec/types.test.ts
@@ -9,30 +9,31 @@ import { DEFAULT_CONTEXT } from "src/types/context"
 const withSessionToken: Middleware<
   {},
   { auth: { session_token: { user: "lucille" } } }
-> = (next, req) => {
+> = (req, ctx, next) => {
   req.auth = { ...req.auth, session_token: { user: "lucille" } }
-  return next(req)
+  return next(req, ctx)
 }
 
 const withPat: Middleware<{}, { auth: { pat: { user: "lucille" } } }> = (
-  next,
-  req
+  req,
+  ctx,
+  next
 ) => {
   req.auth = { ...req.auth, pat: { user: "lucille" } }
-  return next(req)
+  return next(req, ctx)
 }
 
 const withApiToken: Middleware<
   {},
   { auth: { api_token: { user: "lucille" } } }
-> = (next, req) => {
+> = (req, ctx, next) => {
   req.auth = { ...req.auth, api_token: { user: "lucille" } }
-  return next(req)
+  return next(req, ctx)
 }
 
-const withName: Middleware<{}, { name: string }> = (next, req) => {
+const withName: Middleware<{}, { name: string }> = (req, ctx, next) => {
   req.name = "lucille"
-  return next(req)
+  return next(req, ctx)
 }
 
 test.skip("auth none is always supported", () => {
@@ -90,7 +91,7 @@ test.skip("can select existing middleware", () => {
     productionServerUrl: "https://example.com",
 
     authMiddlewareMap: {
-      session_token: (next, req) => next(req),
+      session_token: (req, ctx, next) => next(req, ctx),
     },
     globalMiddlewares: [],
   })
@@ -240,9 +241,10 @@ test.skip("route param types", () => {
 })
 
 const middlewareWithInputs: Middleware<{ x: number }, { y: number }> = (
-  next,
-  req
-) => next(req)
+  req,
+  ctx,
+  next
+) => next(req, ctx)
 
 test.skip("allows middleware with inputs", () => {
   const withEdgeSpec = createWithEdgeSpec({

--- a/tests/testing/ava/fixture.test.ts
+++ b/tests/testing/ava/fixture.test.ts
@@ -15,9 +15,9 @@ test("AVA fixture works", async (t) => {
 })
 
 test("middleware is injected", async (t) => {
-  const sampleMiddleware: Middleware<{}, { foo: "bar" }> = (next, req) => {
+  const sampleMiddleware: Middleware<{}, { foo: "bar" }> = (req, ctx, next) => {
     req.foo = "bar"
-    return next(req)
+    return next(req, ctx)
   }
 
   const { port } = await getTestServer(t, {


### PR DESCRIPTION
Does these things:

> middlewares will accept (req, ctx, next)
> route handlers will accept (req, ctx)
> req doesn’t change from the existing implementation in edgespec
> ctx has some helper methods (typed!) like ctx.json() that return an EdgeSpecResponse