### PR TITLE
global middleware name changes

### DIFF
--- a/docs/global-route-config.md
+++ b/docs/global-route-config.md
@@ -15,8 +15,8 @@ import { createWithEdgeSpec } from "edgespec"
 export const withEdgeSpec = createWithEdgeSpec({
   apiName: "hello-world",
 
-  authMiddlewareMap: {},
-  globalMiddlewares: [],
+  authMiddlewares: {},
+  beforeAuthMiddlewares: [],
 
   productionServerUrl: "https://example.com",
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -65,7 +65,7 @@ export const databaseMiddleware: Middleware<
 }
 
 export const bearerAuthMiddleware: Middleware<
-  // Required request options (Middleware "input"). Assumes that the database middleware has already been called, maybe as part of `globalMiddlewares[]` in `createWithEdgeSpec`.
+  // Required request options (Middleware "input"). Assumes that the database middleware has already been called, maybe as part of `beforeAuthMiddlewares[]` in `createWithEdgeSpec`.
   {
     db: DatabaseClient
   },
@@ -94,7 +94,7 @@ export const bearerAuthMiddleware: Middleware<
 
 ## Authentication Middleware
 
-Authentication middleware is just like any other middleware, except by passing it to `authMiddlewareMap` in `createWithEdgeSpec`, you can specify it as a valid `auth` option on a route. Using the `auth` option is usually simpler and will also affect code generation.
+Authentication middleware is just like any other middleware, except by passing it to `authMiddlewares` in `createWithEdgeSpec`, you can specify it as a valid `auth` option on a route. Using the `auth` option is usually simpler and will also affect code generation.
 
 For example:
 
@@ -106,11 +106,11 @@ import { withApiKey, withBrowserSession } from "src/middlewares"
 export const withEdgeSpec = createWithEdgeSpec({
   apiName: "hello-world",
 
-  authMiddlewareMap: {
+  authMiddlewares: {
     apiKey: withApiKey,
     browserSession: withBrowserSession,
   },
-  globalMiddlewares: [],
+  beforeAuthMiddlewares: [],
 
   productionServerUrl: "https://example.com",
 })

--- a/examples/hello-world/src/with-edge-spec.ts
+++ b/examples/hello-world/src/with-edge-spec.ts
@@ -5,6 +5,6 @@ export const withEdgeSpec = createWithEdgeSpec({
   apiName: "hello-world",
   productionServerUrl: "https://example.com",
 
-  authMiddlewareMap: {},
-  globalMiddlewares: [withDefaultExceptionHandling],
+  authMiddlewares: {},
+  beforeAuthMiddlewares: [withDefaultExceptionHandling],
 })

--- a/recipes/adding-edgespec-to-existing-project.md
+++ b/recipes/adding-edgespec-to-existing-project.md
@@ -21,8 +21,8 @@ import { createWithEdgeSpec } from "edgespec"
 export const withRouteSpec = createWithEdgeSpec({
   apiName: "An Example API",
   productionServerUrl: "https://example.com",
-  globalMiddlewares: [],
-  authMiddlewareMap: {},
+  beforeAuthMiddlewares: [],
+  authMiddlewares: {},
 })
 ```
 

--- a/src/create-with-edge-spec.ts
+++ b/src/create-with-edge-spec.ts
@@ -34,7 +34,7 @@ export const createWithEdgeSpec = <const GS extends GlobalSpec>(
           : [routeSpec.auth]
     )
 
-    const authMiddlewares = Object.entries(globalSpec.authMiddlewareMap)
+    const authMiddlewares = Object.entries(globalSpec.authMiddlewares)
       .filter(([k, _]) => supportedAuthMiddlewares.has(k))
       .map(([_, v]) => v)
 
@@ -48,12 +48,12 @@ export const createWithEdgeSpec = <const GS extends GlobalSpec>(
           : []),
         withUnhandledExceptionHandling,
         serializeResponse(globalSpec, routeSpec, false),
-        ...globalSpec.globalMiddlewares,
+        ...globalSpec.beforeAuthMiddlewares,
         firstAuthMiddlewareThatSucceeds(
           authMiddlewares,
           onMultipleAuthMiddlewareFailures
         ),
-        ...(globalSpec.globalMiddlewaresAfterAuth ?? []),
+        ...(globalSpec.afterAuthMiddlewares ?? []),
         ...(routeSpec.middlewares ?? []),
         withMethods(routeSpec.methods),
         withInputValidation({

--- a/src/types/global-spec.ts
+++ b/src/types/global-spec.ts
@@ -12,9 +12,9 @@ export type QueryArrayFormat = "brackets" | "comma" | "repeat"
 export type QueryArrayFormats = readonly QueryArrayFormat[]
 
 export type GlobalSpec = {
-  authMiddlewareMap: Record<string, Middleware<any, any>>
-  globalMiddlewares: readonly Middleware<unknown, unknown, {}>[]
-  globalMiddlewaresAfterAuth?: readonly Middleware<any, any>[]
+  authMiddlewares: Record<string, Middleware<any, any>>
+  beforeAuthMiddlewares: readonly Middleware<unknown, unknown, {}>[]
+  afterAuthMiddlewares?: readonly Middleware<any, any>[]
 
   // These improve OpenAPI generation
   apiName: string
@@ -37,4 +37,4 @@ export type GlobalSpec = {
 }
 
 export type GetAuthMiddlewaresFromGlobalSpec<GS extends GlobalSpec> =
-  InferRecordKey<GS["authMiddlewareMap"]>
+  InferRecordKey<GS["authMiddlewares"]>

--- a/src/types/route-spec.ts
+++ b/src/types/route-spec.ts
@@ -82,14 +82,14 @@ type GetMiddlewareRequestOptions<
   GS extends GlobalSpec,
   RS extends RouteSpec<GetAuthMiddlewaresFromGlobalSpec<GS>>,
 > = AccumulateMiddlewareChainResultOptions<
-  GS["globalMiddlewares"],
+  GS["beforeAuthMiddlewares"],
   "intersection"
 > &
   (RS["auth"] extends "none"
     ? {}
     : AccumulateMiddlewareChainResultOptions<
         MapMiddlewares<
-          GS["authMiddlewareMap"],
+          GS["authMiddlewares"],
           RS["auth"] extends undefined | null
             ? "none"
             : Exclude<RS["auth"], undefined | null>
@@ -97,8 +97,8 @@ type GetMiddlewareRequestOptions<
         "union"
       >) &
   AccumulateMiddlewareChainResultOptions<
-    GS["globalMiddlewaresAfterAuth"] extends MiddlewareChain
-      ? GS["globalMiddlewaresAfterAuth"]
+    GS["afterAuthMiddlewares"] extends MiddlewareChain
+      ? GS["afterAuthMiddlewares"]
       : readonly [],
     "intersection"
   > &

--- a/tests/cli/codegen/route-types/with-edge-spec.ts
+++ b/tests/cli/codegen/route-types/with-edge-spec.ts
@@ -4,6 +4,6 @@ import { createWithEdgeSpec } from "../../../../src"
 export const withEdgeSpec = createWithEdgeSpec({
   apiName: "hello-world",
   productionServerUrl: "https://example.com",
-  authMiddlewareMap: {},
-  globalMiddlewares: [],
+  authMiddlewares: {},
+  beforeAuthMiddlewares: [],
 })

--- a/tests/endpoints/basic-01.test.ts
+++ b/tests/endpoints/basic-01.test.ts
@@ -7,8 +7,8 @@ test("basic-01", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [],
     },
     routeSpec: {
       auth: "none",

--- a/tests/endpoints/json-body-01.test.ts
+++ b/tests/endpoints/json-body-01.test.ts
@@ -8,8 +8,8 @@ test("json-body-01", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [],
     },
     routeSpec: {
       auth: "none",

--- a/tests/middleware-injection/nodejs/with-route-spec.ts
+++ b/tests/middleware-injection/nodejs/with-route-spec.ts
@@ -14,8 +14,8 @@ const sampleMiddleware: Middleware<{}, { middlewareType: string }> = (
 }
 
 export const withRouteSpec = createWithEdgeSpec({
-  globalMiddlewares: [sampleMiddleware],
-  authMiddlewareMap: {},
+  beforeAuthMiddlewares: [sampleMiddleware],
+  authMiddlewares: {},
   apiName: "Example",
   productionServerUrl: "https://example.com",
 })

--- a/tests/middleware-injection/wintercg/with-route-spec.ts
+++ b/tests/middleware-injection/wintercg/with-route-spec.ts
@@ -14,8 +14,8 @@ const sampleMiddleware: Middleware<{}, { middlewareType: string }> = (
 }
 
 export const withRouteSpec = createWithEdgeSpec({
-  globalMiddlewares: [sampleMiddleware],
-  authMiddlewareMap: {},
+  beforeAuthMiddlewares: [sampleMiddleware],
+  authMiddlewares: {},
   apiName: "Example",
   productionServerUrl: "https://example.com",
 })

--- a/tests/middleware/with-default-exception-handling.test.ts
+++ b/tests/middleware/with-default-exception-handling.test.ts
@@ -9,8 +9,8 @@ test("handles internal middleware issues", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [withDefaultExceptionHandling],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [withDefaultExceptionHandling],
     },
     routeSpec: {
       auth: "none",
@@ -38,8 +38,8 @@ test("handles custom http exceptions", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [withDefaultExceptionHandling],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [withDefaultExceptionHandling],
     },
     routeSpec: {
       auth: "none",

--- a/tests/middleware/with-input-validation.test.ts
+++ b/tests/middleware/with-input-validation.test.ts
@@ -10,8 +10,8 @@ const defaultSpecs = {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [
       async (req, ctx, next) => {
         try {
           return await next(req, ctx)

--- a/tests/middleware/with-unhandled-exception-handling.test.ts
+++ b/tests/middleware/with-unhandled-exception-handling.test.ts
@@ -7,8 +7,8 @@ test("unhandled exception doesn't explode", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [],
     },
     routeSpec: {
       auth: "none",

--- a/tests/route-spec/middleware.test.ts
+++ b/tests/route-spec/middleware.test.ts
@@ -32,12 +32,12 @@ test("receives auth middleware", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {
+      authMiddlewares: {
         pat: withPat,
         api_token: withApiToken,
         session_token: withSessionToken,
       },
-      globalMiddlewares: [],
+      beforeAuthMiddlewares: [],
     },
     routeSpec: {
       auth: ["pat", "api_token", "session_token"],
@@ -67,11 +67,11 @@ test("fails if all auth middleware fail", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {
+      authMiddlewares: {
         pat: withPat,
         api_token: withApiToken,
       },
-      globalMiddlewares: [
+      beforeAuthMiddlewares: [
         async (req, ctx, next) => {
           try {
             return await next(req, ctx)
@@ -115,21 +115,21 @@ test("middlewares run in correct order", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      globalMiddlewares: [
+      beforeAuthMiddlewares: [
         (req, ctx, next) => {
           t.is(counter++, 0)
           return next(req, ctx)
         },
       ],
 
-      authMiddlewareMap: {
+      authMiddlewares: {
         pat: (req, ctx, next) => {
           t.is(counter++, 1)
           return next(req, ctx)
         },
       },
 
-      globalMiddlewaresAfterAuth: [
+      afterAuthMiddlewares: [
         (req, ctx, next) => {
           t.is(counter++, 2)
           return next(req, ctx)
@@ -162,8 +162,8 @@ test("receives route middleware", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [withName],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [withName],
     },
     routeSpec: {
       auth: "none",
@@ -185,8 +185,8 @@ test("receives local middleware", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [],
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [],
     },
     routeSpec: {
       auth: "none",
@@ -209,8 +209,8 @@ test("responseDefaults are passed", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {},
-      globalMiddlewares: [
+      authMiddlewares: {},
+      beforeAuthMiddlewares: [
         (req, ctx, next) => {
           req.responseDefaults.headers.set("x-test", "test")
           req.responseDefaults.headers.set("x-test2", "test2")
@@ -251,12 +251,12 @@ test("allows omitting auth field in route spec", async (t) => {
       apiName: "hello-world",
       productionServerUrl: "https://example.com",
 
-      authMiddlewareMap: {
+      authMiddlewares: {
         pat: withPat,
         api_token: withApiToken,
         session_token: withSessionToken,
       },
-      globalMiddlewares: [],
+      beforeAuthMiddlewares: [],
     },
     routeSpec: {
       methods: ["GET"],

--- a/tests/route-spec/responses.test.ts
+++ b/tests/route-spec/responses.test.ts
@@ -10,8 +10,8 @@ const defaultSpecs = {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [
       async (req, ctx, next) => {
         try {
           return await next(req, ctx)

--- a/tests/route-spec/types.test.ts
+++ b/tests/route-spec/types.test.ts
@@ -41,8 +41,8 @@ test.skip("auth none is always supported", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [],
   })({
     auth: "none",
     methods: ["GET"],
@@ -54,8 +54,8 @@ test.skip("auth none cannot be provided in an array", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [],
   })({
     // @ts-expect-error
     auth: ["none"],
@@ -68,8 +68,8 @@ test.skip("cannot select non-existent auth methods", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -90,10 +90,10 @@ test.skip("can select existing middleware", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {
+    authMiddlewares: {
       session_token: (req, ctx, next) => next(req, ctx),
     },
-    globalMiddlewares: [],
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -112,8 +112,8 @@ test.skip("middleware objects are available", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [withName],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [withName],
   })
 
   withEdgeSpec({
@@ -131,10 +131,10 @@ test.skip("auth middleware objects are available as singleton", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {
+    authMiddlewares: {
       session_token: withSessionToken,
     },
-    globalMiddlewares: [],
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -154,12 +154,12 @@ test.skip("auth middleware objects are available as union", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {
+    authMiddlewares: {
       session_token: withSessionToken,
       pat: withPat,
       api_token: withApiToken,
     },
-    globalMiddlewares: [],
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -184,8 +184,8 @@ test.skip("route-local middlewares are available to request", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -204,8 +204,8 @@ test.skip("custom response map types are enforced", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -226,8 +226,8 @@ test.skip("route param types", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {},
-    globalMiddlewares: [],
+    authMiddlewares: {},
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -251,10 +251,10 @@ test.skip("allows middleware with inputs", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {
+    authMiddlewares: {
       test: middlewareWithInputs,
     },
-    globalMiddlewares: [],
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({
@@ -272,10 +272,10 @@ test.skip("typed ctx.json()", () => {
     apiName: "hello-world",
     productionServerUrl: "https://example.com",
 
-    authMiddlewareMap: {
+    authMiddlewares: {
       test: middlewareWithInputs,
     },
-    globalMiddlewares: [],
+    beforeAuthMiddlewares: [],
   })
 
   withEdgeSpec({

--- a/tests/testing/ava/with-route-spec.ts
+++ b/tests/testing/ava/with-route-spec.ts
@@ -1,8 +1,8 @@
 import { createWithEdgeSpec } from "../../../src"
 
 export const withRouteSpec = createWithEdgeSpec({
-  globalMiddlewares: [],
-  authMiddlewareMap: {},
+  beforeAuthMiddlewares: [],
+  authMiddlewares: {},
   apiName: "Example",
   productionServerUrl: "https://example.com",
 })


### PR DESCRIPTION
From this thread: https://hello-seam.slack.com/archives/C067LNPPKR7/p1707935173111969

- `globalMiddlewares` => `beforeAuthMiddlewares`
- `globalMiddlewaresAfterAuth` => `afterAuthMiddlewares`
- `authMiddlewareMap` => `authMiddlewares`