### PR TITLE
Fix Node middleware injection

### DIFF
--- a/src/dev/headless/request-handler-controller.ts
+++ b/src/dev/headless/request-handler-controller.ts
@@ -83,7 +83,10 @@ export class RequestHandlerController {
           `file:${await this.bundlePathPromise}#${Date.now()}`
         )
 
-        this.cachedNodeHandler = edgeSpecModule.makeRequest
+        this.cachedNodeHandler = async (req) =>
+          edgeSpecModule.makeRequest(req, {
+            middleware: this.middleware,
+          })
 
         return this.cachedNodeHandler
       })

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -28,7 +28,6 @@ export const getTestServer = async (
     rootDirectory: path.join(routesDirectory, ".."),
     config: {
       routesDirectory,
-      platform: "wintercg-minimal",
     },
     port: await getPort(),
     middleware: options?.middleware,


### PR DESCRIPTION
Test was actually running in an edge VM because the `platform: node` option was being overridden.
