### PR TITLE
auth field should not be required for types

### DIFF
--- a/src/types/route-spec.ts
+++ b/src/types/route-spec.ts
@@ -89,15 +89,17 @@ type GetMiddlewareRequestOptions<
 > &
   (RS["auth"] extends "none"
     ? {}
-    : AccumulateMiddlewareChainResultOptions<
-        MapMiddlewares<
-          GS["authMiddleware"],
-          RS["auth"] extends undefined | null
-            ? "none"
-            : Exclude<RS["auth"], undefined | null>
-        >,
-        "union"
-      >) &
+    : undefined extends RS["auth"]
+      ? {}
+      : AccumulateMiddlewareChainResultOptions<
+          MapMiddlewares<
+            GS["authMiddleware"],
+            RS["auth"] extends undefined | null
+              ? "none"
+              : Exclude<RS["auth"], undefined | null>
+          >,
+          "union"
+        >) &
   AccumulateMiddlewareChainResultOptions<
     GS["afterAuthMiddleware"] extends MiddlewareChain
       ? GS["afterAuthMiddleware"]

--- a/tests/route-spec/types.test.ts
+++ b/tests/route-spec/types.test.ts
@@ -45,6 +45,17 @@ test.skip("auth none is always supported", () => {
   })
 })
 
+test.skip("auth none is optional", () => {
+  createWithEdgeSpec({
+    authMiddleware: {},
+  })({
+    methods: ["GET"],
+  })((req, _) => {
+    expectTypeOf(req).not.toBeNever()
+    return new Response()
+  })
+})
+
 test.skip("auth none cannot be provided in an array", () => {
   createWithEdgeSpec({
     authMiddleware: {},


### PR DESCRIPTION
bug where if auth was not set then the types failed and `req` became `never`