### PR TITLE
Use _input from Zod schema for route type gen instead of _output

### DIFF
--- a/src/cli/commands/codegen/route-types.ts
+++ b/src/cli/commands/codegen/route-types.ts
@@ -191,7 +191,7 @@ function getZodTypeOfSymbol(project: Project, symbol: Symbol | undefined) {
     .getTypeChecker()
     .getTypeOfSymbolAtLocation(symbol, symbol.getValueDeclarationOrThrow())
 
-  const innerType = outerType.getProperty("_output")
+  const innerType = outerType.getProperty("_input")
   if (!innerType) {
     throw new Error(`${symbol.getName()} must be a zod schema`)
   }

--- a/tests/cli/codegen/route-types/api/param-transform.ts
+++ b/tests/cli/codegen/route-types/api/param-transform.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+import { withEdgeSpec } from "../with-edge-spec.js"
+
+export default withEdgeSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  jsonBody: z.object({
+    // this should be written to route types as a string rather than a number
+    foo_id: z.string().transform((v) => Number(v)),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+  }),
+})((req) => {
+  return Response.json({
+    foo: {
+      id: "example-id",
+      name: "foo",
+    },
+  })
+})

--- a/tests/cli/codegen/route-types/route-type-codegen.test.ts
+++ b/tests/cli/codegen/route-types/route-type-codegen.test.ts
@@ -114,6 +114,17 @@ test("CLI codegen route-types command produces the expected route types", async 
           }
         }
       }
+      // Route that uses .transform()
+      "/param-transform": {
+        route: "/param-transform"
+        method: "GET" | "POST"
+        jsonResponse: {
+          ok: boolean
+        }
+        jsonBody: {
+          foo_id: string
+        }
+      }
     }
 
     expectTypeOf<Routes>().toEqualTypeOf<ExpectedRoutes>()
@@ -123,16 +134,7 @@ test("CLI codegen route-types command produces the expected route types", async 
   const diagnostics = project.getPreEmitDiagnostics()
 
   if (diagnostics.length > 0) {
-    for (const diagnostic of diagnostics) {
-      let message = diagnostic.getMessageText()
-      message = typeof message === "string" ? message : message.getMessageText()
-
-      t.log(
-        `${diagnostic.getCategory()} ${message} (${diagnostic
-          .getSourceFile()
-          ?.getFilePath()}:${diagnostic.getLineNumber()})`
-      )
-    }
+    t.log(project.formatDiagnosticsWithColorAndContext(diagnostics))
 
     t.fail(
       "Test TypeScript project using generated routes threw compile errors"


### PR DESCRIPTION
Closes https://github.com/seamapi/edgespec/issues/98.
