### PR TITLE
node handler adapter

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,3 +1,4 @@
+import { NodeHandler } from "@edge-runtime/node-utils"
 import http from "node:http"
 import { transformToNodeBuilder } from "src/edge-runtime/transform-to-node"
 import type { Middleware } from "src/middleware"
@@ -8,21 +9,28 @@ export interface EdgeSpecNodeAdapterOptions {
   port?: number
 }
 
-export const startServer: EdgeSpecAdapter<
+export const getNodeHandler: EdgeSpecAdapter<
   [EdgeSpecNodeAdapterOptions],
-  Promise<http.Server>
-> = async (edgeSpec, { port, middleware = [] }) => {
+  NodeHandler
+> = (edgeSpec, { port, middleware = [] }) => {
   const transformToNode = transformToNodeBuilder({
     defaultOrigin: `http://localhost${port ? `:${port}` : ""}`,
   })
 
-  const server = http.createServer(
-    transformToNode((req) =>
-      edgeSpec.makeRequest(req, {
-        middleware,
-      })
-    )
+  return transformToNode((req) =>
+    edgeSpec.makeRequest(req, {
+      middleware,
+    })
   )
+}
+
+export const startServer: EdgeSpecAdapter<
+  [EdgeSpecNodeAdapterOptions],
+  Promise<http.Server>
+> = async (edgeSpec, opts) => {
+  const server = http.createServer(getNodeHandler(edgeSpec, opts))
+
+  const { port } = opts
 
   await new Promise<void>((resolve) => server.listen(port, resolve))
 

--- a/tests/adapters/node.test.ts
+++ b/tests/adapters/node.test.ts
@@ -9,7 +9,7 @@ import pRetry from "p-retry"
 import axios from "axios"
 import { once } from "node:events"
 
-test("test bundle with Node adapter", async (t) => {
+test.serial("test bundle with Node adapter", async (t) => {
   const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
 
   const bundled = await bundle({
@@ -81,3 +81,85 @@ test("test bundle with Node adapter", async (t) => {
   const response = await axios.get(`http://localhost:${port}/health`)
   t.is(response.data.foo, "bar")
 })
+
+test.serial(
+  "test bundle with Node adapter and manual server start",
+  async (t) => {
+    const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
+
+    const bundled = await bundle({
+      routesDirectory: path.join(currentDirectory, "api"),
+      rootDirectory: currentDirectory,
+    })
+
+    const port = await getPort()
+
+    const bundlePath = path.join(currentDirectory, "bundled.js")
+    const bundleEntrypointPath = path.join(
+      currentDirectory,
+      "bundled.entrypoint.mjs"
+    )
+    await fs.writeFile(bundlePath, bundled, "utf-8")
+    await fs.writeFile(
+      bundleEntrypointPath,
+      `
+    import http from "node:http"
+
+    import {getNodeHandler} from "../../dist/adapters/node.js"
+    import bundle from "./bundled.js"
+
+    const fooMiddleware = (req, ctx, next) => {
+      req.foo = "bar"
+      return next(req, ctx)
+    }
+
+    const nodeHandler = getNodeHandler(bundle, { port: ${port}, middleware: [fooMiddleware] })
+
+    const server = http.createServer(nodeHandler)
+
+    server.listen(${port})
+  `,
+      "utf-8"
+    )
+
+    const cmd = execa("node", [bundleEntrypointPath])
+
+    cmd.stderr!.on("data", (data) => {
+      console.error("From child process: " + data.toString())
+    })
+
+    cmd.stdout!.on("data", (data) => {
+      console.log("From child process: " + data.toString())
+    })
+
+    cmd.addListener("close", (code) => {
+      if (code) t.fail(`Server exited with code ${code}`)
+    })
+
+    const waitForExit = once(cmd, "exit")
+
+    t.teardown(async () => {
+      cmd.kill("SIGTERM")
+      await waitForExit
+    })
+
+    await pRetry(
+      async () => {
+        try {
+          const response = await axios.get(`http://localhost:${port}/health`)
+
+          t.true(response.data.ok)
+        } catch (e: any) {
+          t.log("axios failed (a few failures expected): " + e.message)
+          throw e
+        }
+      },
+      {
+        retries: 3,
+      }
+    )
+
+    const response = await axios.get(`http://localhost:${port}/health`)
+    t.is(response.data.foo, "bar")
+  }
+)


### PR DESCRIPTION
Allows getting the underlying `NodeHandler` for a node server, instead of starting an entire server

Closes #95 