### PR TITLE
External Packages whenever platform is node

### DIFF
--- a/src/cli/commands/bundle.ts
+++ b/src/cli/commands/bundle.ts
@@ -32,23 +32,11 @@ export class BundleCommand extends BaseCommand {
 
     let platformBundleOptions: Partial<BundleOptions> = {}
 
-    const rootDirPackageJson = await readFile(
-      joinPath(config.rootDirectory, "package.json")
-    )
-      .then((r) => JSON.parse(r.toString()))
-      .catch((e) => {
-        throw new Error(
-          `Could not read package.json in ${
-            config.rootDirectory
-          }\n\n${e.toString()}`
-        )
-      })
-
     if (config.platform === "node") {
       platformBundleOptions = {
         esbuild: {
           platform: "node",
-          external: Object.keys(rootDirPackageJson.dependencies || {}),
+          packages: "external",
         },
       }
     }

--- a/src/dev/headless/start-bundler.ts
+++ b/src/dev/headless/start-bundler.ts
@@ -29,6 +29,7 @@ export const startHeadlessDevBundler = async ({
       config.platform === "wintercg-minimal" ? "wintercg-minimal" : undefined,
     esbuild: {
       platform: config.platform === "wintercg-minimal" ? "browser" : "node",
+      packages: "external",
       outfile: devBundlePath,
       write: true,
       plugins: [

--- a/src/dev/headless/start-bundler.ts
+++ b/src/dev/headless/start-bundler.ts
@@ -29,7 +29,7 @@ export const startHeadlessDevBundler = async ({
       config.platform === "wintercg-minimal" ? "wintercg-minimal" : undefined,
     esbuild: {
       platform: config.platform === "wintercg-minimal" ? "browser" : "node",
-      packages: "external",
+      packages: config.platform === "node" ? "external" : undefined,
       outfile: devBundlePath,
       write: true,
       plugins: [


### PR DESCRIPTION
Allows pg to be imported, albeit it seems like the import isn't correctly using the tsconfig.

- packages external to fix node packaging
- only use external packages if platform is node
