### PR TITLE
explain initial serialize response

### DIFF
--- a/src/create-with-edge-spec.ts
+++ b/src/create-with-edge-spec.ts
@@ -47,7 +47,14 @@ export const createWithEdgeSpec = <const GS extends GlobalSpec>(
             _injectedEdgeSpecMiddleware
           : []),
         withUnhandledExceptionHandling,
-        // todo: remove
+        // this serializes responses that are returned by middleware WITHOUT
+        // validating them against the routeSpec
+        //
+        // this allows returning EdgeSpecResponse.json or ctx.json in a
+        // middleware, instead of having to return a raw Response
+        //
+        // this is needed, for instance, when an error middleware returns an
+        // error response that does not match the routeSpec's response shape
         serializeResponse(globalSpec, routeSpec, false),
         ...(globalSpec.beforeAuthMiddleware ?? []),
         firstAuthMiddlewareThatSucceeds(
@@ -71,6 +78,8 @@ export const createWithEdgeSpec = <const GS extends GlobalSpec>(
           urlEncodedFormData: routeSpec.urlEncodedFormData,
           shouldValidateGetRequestBody: globalSpec.shouldValidateGetRequestBody,
         }),
+        // this serializes responses that are returned by the route function,
+        // validating them against the routeSpec
         serializeResponse(globalSpec, routeSpec),
       ],
       routeFn,


### PR DESCRIPTION
It's a little confusing why there are two `serializeResponse` middleware in `create-with-edge-spec`, so I added some comments to clarify their purposes