### PR TITLE
Better unhandled internal error printing

### DIFF
--- a/src/dev/headless/start-server.ts
+++ b/src/dev/headless/start-server.ts
@@ -68,7 +68,11 @@ export const startHeadlessDevServer = async ({
           )
         } else {
           process.stderr.write(
-            "Unhandled exception:\n" + JSON.stringify(error) + "\n"
+            "Unhandled exception:\n" +
+              ((error as any).stack
+                ? (error as any).stack
+                : JSON.stringify(error)) +
+              "\n"
           )
         }
 


### PR DESCRIPTION
`JSON.stringify(new Error()) == "{}"`
