### PR TITLE
Output CJS when bundling for edge runtime emulation

### DIFF
--- a/src/dev/headless/start-bundler.ts
+++ b/src/dev/headless/start-bundler.ts
@@ -50,6 +50,7 @@ export const startHeadlessDevBundler = async ({
     esbuild: {
       platform: config.platform === "wintercg-minimal" ? "browser" : "node",
       packages: config.platform === "node" ? "external" : undefined,
+      format: config.platform === "wintercg-minimal" ? "cjs" : "esm",
       outfile: devBundlePath,
       write: true,
       plugins: [


### PR DESCRIPTION
The underlying Node.js VM API that the edge runtime package uses doesn't support ESM/modules. There's a new VM API that does support modules, but it's not stable yet and currently behind an experimental flag.

Hoping that bundling for CJS in dev and ESM for deployment won't lead to unexpected issues; if it does we can revisit this and add additional documentation and/or options.
