### PR TITLE
Ensure generated bundle is imported as ESM during OpenAPI generation

### DIFF
--- a/src/cli/commands/codegen/openapi.ts
+++ b/src/cli/commands/codegen/openapi.ts
@@ -64,7 +64,7 @@ export class CodeGenOpenAPI extends BaseCommand {
   })
 
   async run(config: ResolvedEdgeSpecConfig) {
-    const tempBundlePath = path.join(os.tmpdir(), `${randomUUID()}.js`)
+    const tempBundlePath = path.join(os.tmpdir(), `${randomUUID()}.mjs`)
     await fs.writeFile(tempBundlePath, await bundle(config))
     const runtimeBundle = await loadBundle(tempBundlePath)
 


### PR DESCRIPTION
Fixes an issue in the fake-template.
