### PR TITLE
properly export `dev`, `config` sub-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
       "types": "./dist/index.d.ts"
     },
     "./config": {
-      "import": "./dist/config.js",
-      "require": "./dist/config.js",
-      "types": "./dist/config/config.d.ts"
+      "import": "./dist/config/index.js",
+      "require": "./dist/config/index.js",
+      "types": "./dist/config/index.d.ts"
     },
     "./dev": {
-      "import": "./dist/dev.js",
-      "require": "./dist/dev.js",
-      "types": "./dist/dev.d.ts"
+      "import": "./dist/dev/index.js",
+      "require": "./dist/dev/index.js",
+      "types": "./dist/dev/index.d.ts"
     },
     "./middleware": {
       "import": "./dist/middleware/index.js",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,2 @@
 export { loadConfig } from "./utils.js"
+export * from "./config.js"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,7 @@
     "src/middleware/index.ts",
     "src/adapters/node.ts",
     "src/adapters/wintercg-minimal.ts",
-    "src/dev/dev.ts",
+    "src/dev/index.ts",
     "src/config/index.ts",
     "src/testing/ava/index.ts",
     "src/testing/ava/worker-wrapper.ts",


### PR DESCRIPTION
Looks like `dev` is some sort of reserved keyword or something, it wouldn't let me import it in my project

And then for config, we are currently not exposing `defineConfig` so I fixed that