### PR TITLE
fix `edgespec/dev` import

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
       "types": "./dist/config/index.d.ts"
     },
     "./dev": {
-      "import": "./dist/dev/index.js",
-      "require": "./dist/dev/index.js",
-      "types": "./dist/dev/index.d.ts"
+      "import": "./dist/dev/dev.js",
+      "require": "./dist/dev/dev.js",
+      "types": "./dist/dev/dev.d.ts"
     },
     "./middleware": {
       "import": "./dist/middleware/index.js",


### PR DESCRIPTION
There is no `index.js` file in the `dist` directory, it exports a `dev.js` file

![image](https://github.com/seamapi/edgespec/assets/1910070/96a4b4cf-a0ba-4399-ac06-40377662ab2c)
