### PR TITLE
fix: Allow importing CJS files directly with CommonJS module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,39 +11,74 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./config": {
-      "types": "./dist/config/index.d.ts",
-      "import": "./dist/config/index.js",
-      "require": "./dist/config/index.cjs"
+      "import": {
+        "types": "./dist/config/index.d.ts",
+        "default": "./dist/config/index.js"
+      },
+      "require": {
+        "types": "./dist/config/index.d.cts",
+        "default": "./dist/config/index.cjs"
+      }
     },
     "./dev": {
-      "types": "./dist/dev/dev.d.ts",
-      "import": "./dist/dev/dev.js",
-      "require": "./dist/dev/dev.cjs"
+      "import": {
+        "types": "./dist/dev/dev.d.ts",
+        "default": "./dist/dev/dev.js"
+      },
+      "require": {
+        "types": "./dist/dev/dev.d.cts",
+        "default": "./dist/dev/dev.cjs"
+      }
     },
     "./middleware": {
-      "types": "./dist/middleware/index.d.ts",
-      "import": "./dist/middleware/index.js",
-      "require": "./dist/middleware/index.cjs"
+      "import": {
+        "types": "./dist/middleware/index.d.ts",
+        "default": "./dist/middleware/index.js"
+      },
+      "require": {
+        "types": "./dist/middleware/index.d.cts",
+        "default": "./dist/middleware/index.cjs"
+      }
     },
     "./adapters/node": {
-      "types": "./dist/adapters/node.d.ts",
-      "import": "./dist/adapters/node.js",
-      "require": "./dist/adapters/node.cjs"
+      "import": {
+        "types": "./dist/adapters/node.d.ts",
+        "default": "./dist/adapters/node.js"
+      },
+      "require": {
+        "types": "./dist/adapters/node.d.cts",
+        "default": "./dist/adapters/node.cjs"
+      }
     },
     "./adapters/wintercg-minimal": {
-      "types": "./dist/adapters/wintercg-minimal.d.ts",
-      "import": "./dist/adapters/wintercg-minimal.js",
-      "require": "./dist/adapters/wintercg-minimal.cjs"
+      "import": {
+        "types": "./dist/adapters/wintercg-minimal.d.ts",
+        "default": "./dist/adapters/wintercg-minimal.js"
+      },
+      "require": {
+        "types": "./dist/adapters/wintercg-minimal.d.cts",
+        "default": "./dist/adapters/wintercg-minimal.cjs"
+      }
     },
     "./testing/ava": {
-      "types": "./dist/testing/ava/index.d.ts",
-      "import": "./dist/testing/ava/index.js",
-      "require": "./dist/testing/ava/index.cjs"
+      "import": {
+        "types": "./dist/testing/ava/index.d.ts",
+        "default": "./dist/testing/ava/index.js"
+      },
+      "require": {
+        "types": "./dist/testing/ava/index.d.cts",
+        "default": "./dist/testing/ava/index.cjs"
+      }
     },
     "./dist/config/index.cjs": "./dist/config/index.cjs",
     "./dist/dev/dev.cjs": "./dist/dev/dev.cjs",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
       "types": "./dist/testing/ava/index.d.ts",
       "import": "./dist/testing/ava/index.js",
       "require": "./dist/testing/ava/index.cjs"
-    }
+    },
+    "./dist/config/index.cjs": "./dist/config/index.cjs",
+    "./dist/dev/dev.cjs": "./dist/dev/dev.cjs",
+    "./dist/middleware/index.cjs": "./dist/middleware/index.cjs",
+    "./dist/adapters/node.cjs": "./dist/adapters/node.cjs",
+    "./dist/adapters/wintercg-minimal.cjs": "./dist/adapters/wintercg-minimal.cjs",
+    "./dist/testing/ava/index.cjs": "./dist/testing/ava/index.cjs"
   },
   "repository": "git@github.com:seamapi/edgespec.git",
   "scripts": {


### PR DESCRIPTION
## Context
seam-connect has a `tsconfig.moduleResolution` set to `node` (and not `Node16` or `NodeNext`) because its `tsconfig.module` is `commonjs`. 

Empirically, this means that:
- Importing `edgespec/middleware` from seam-connect will literally import the file `edgespec/middleware/index.js` (instead of `edgespec/dist/middleware/index.cjs`), ignoring what edgespec says in its `exports` config. 
- Importing `edgespec/dist/middleware/index.cjs` works BUT then `npm run build:nsm` fails because that path is not exported by edgespec in its `exports` (not sure why the `exports` are taken into account only then, it makes for a weird developer experience)

This PR is a MVP solution, a proper solution would involve:
- Having the CJS build output at the root of the project (so the paths `./middleware`, etc.., are valid without needing `exports` to rewrite them)
- Having the package.json `files` include these build outputs (right now, only the `dist` folder is included)
- Having these files be named `.js` instead of `.cjs` => This is where I'm stuck right now, as they might be considered ESM if I were to rename them

The [javascript-http](https://github.com/seamapi/javascript-http/blob/9fd9db56518a8503f70951091926e90621a355b9/package.json) library does something similar. However, it seems like it is outputting ESM and not CJS to the root directory. I believe this might have side-effects (ESM being imported instead of CommonJS) so I did not copy its implementation. Not 100% sure.

## Changes
- Add the CJS files that we want to import directly to the `exports` array so that seam-connect's `npm run build:nsm` works
- Split the ESM/CJS types exports (saw that done in the `javascript-http` project and it makes sense)