### PR TITLE
fix: Add index.cjs to accepted imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "default": "./dist/testing/ava/index.cjs"
       }
     },
+    "./dist/index.cjs": "./dist/index.cjs",
     "./dist/config/index.cjs": "./dist/config/index.cjs",
     "./dist/dev/dev.cjs": "./dist/dev/dev.cjs",
     "./dist/middleware/index.cjs": "./dist/middleware/index.cjs",


### PR DESCRIPTION
## Context
https://github.com/seamapi/edgespec/pull/160

Missed this, importing from `edgespec` and also from `edgespec/dist/middleware/index.cjs` causes type conflicts. The `edgespec` import actually gets its types from the ESM types (not sure why) while the .cjs import gets its types from the CJS types. I will convert my imports to `edgespec/dist/index.cjs` for now

## Changes
- Add `edgespec/dist/index.cjs` to accepted imports