### PR TITLE
feat: add Zod 4 compatibility for query param type detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edgespec",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edgespec",
-      "version": "0.0.75",
+      "version": "0.0.76",
       "license": "ISC",
       "dependencies": {
         "@anatine/zod-openapi": "^2.2.3",
@@ -29,7 +29,7 @@
         "ts-morph": "^21.0.1",
         "watcher": "^2.3.0",
         "yargs": "^17.7.2",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4 || ^4.0.0"
       },
       "bin": {
         "edgespec": "dist/cli/cli.js"
@@ -1254,6 +1254,7 @@
       "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.40.1.tgz",
       "integrity": "sha512-xHn2Zkh6s5JIjP94SG6VtIlIeRJcASgfZpDKV+bgoddMt1X4ujSZFOz7uEGNYNO7mEtdVOvpNKBpC4CDytD8KQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@microsoft/api-extractor-model": "7.28.9",
         "@microsoft/tsdoc": "0.14.2",
@@ -1644,6 +1645,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -1901,6 +1903,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2151,6 +2154,7 @@
       "resolved": "https://registry.npmjs.org/ava/-/ava-6.1.1.tgz",
       "integrity": "sha512-A+DG0Ag0e5zvt262Ze0pG5QH7EBmhn+DB9uK7WkUtJVAtGjZFeKTpUOKx339DMGn53+FB24pCJC5klX2WU4VOw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vercel/nft": "^0.26.2",
         "acorn": "^8.11.3",
@@ -3147,6 +3151,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
       "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5096,6 +5101,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.2.1.tgz",
       "integrity": "sha512-KL1mKwkZii5ce+tb24KCUmQHyWB/oanG5fzUY35UB+wenWJv4Kr/IWBntpn5R8ODiJcxx13ZDophcpHnLGeIOw==",
+      "peer": true,
       "dependencies": {
         "yaml": "^2.3.4"
       }
@@ -5313,6 +5319,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
       "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -6697,6 +6704,7 @@
       "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6877,6 +6885,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.17.0.tgz",
       "integrity": "sha512-eN4mnDA5UMKDt4YZixo9tBioibaMBpoxBkD+rIPAjVmYERSG0/dWEY1CEFuV89CgASlKL499q8AhmkMnnjtOJg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.23.0",
         "get-tsconfig": "^4.7.5"
@@ -7447,6 +7456,7 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "ts-morph": "^21.0.1",
     "watcher": "^2.3.0",
     "yargs": "^17.7.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4 || ^4.0.0"
   },
   "peerDependencies": {
     "@ava/get-port": ">=2.0.0",

--- a/src/cli/commands/codegen/openapi.ts
+++ b/src/cli/commands/codegen/openapi.ts
@@ -108,7 +108,13 @@ export class CodeGenOpenAPI extends BaseCommand {
         const areCommonParamsRequiredInQuery =
           HTTP_METHODS_WITHOUT_BODY.includes(method.toLowerCase())
         if (!areCommonParamsRequiredInQuery) {
-          if (commonParams?._def.typeName === "ZodObject") {
+          // Support both Zod 3 (_def.typeName) and Zod 4 (_def.type)
+          const commonParamsType =
+            commonParams?._def.type ?? commonParams?._def.typeName
+          if (
+            commonParamsType === "ZodObject" ||
+            commonParamsType === "object"
+          ) {
             commonParams = (commonParams as ZodObject<any>).partial()
           } else {
             commonParams = commonParams?.optional()

--- a/src/middleware/with-input-validation.ts
+++ b/src/middleware/with-input-validation.ts
@@ -10,6 +10,28 @@ import {
   InvalidQueryParamsError,
 } from "./http-exceptions.js"
 
+/**
+ * Get the type identifier from a Zod schema definition.
+ * Supports both Zod 3 (_def.typeName) and Zod 4 (_def.type).
+ */
+const getZodTypeIdentifier = (def: any): string | undefined => {
+  // Zod 4 uses _def.type (lowercase string like "string", "boolean", "optional")
+  // Zod 3 uses _def.typeName (ZodFirstPartyTypeKind enum values)
+  return def.type ?? def.typeName
+}
+
+/**
+ * Check if a type identifier matches a specific Zod type.
+ * Supports both Zod 3 (ZodFirstPartyTypeKind) and Zod 4 (lowercase strings).
+ */
+const isZodType = (
+  typeIdentifier: string | undefined,
+  zod3Kind: (typeof ZodFirstPartyTypeKind)[keyof typeof ZodFirstPartyTypeKind],
+  zod4Type: string
+): boolean => {
+  return typeIdentifier === zod3Kind || typeIdentifier === zod4Type
+}
+
 const getZodObjectSchemaFromZodEffectSchema = (
   isZodEffect: boolean,
   schema: z.ZodTypeAny
@@ -18,10 +40,21 @@ const getZodObjectSchemaFromZodEffectSchema = (
     return schema as z.ZodObject<any>
   }
 
-  let currentSchema = schema
+  let currentSchema = schema as any
 
-  while (currentSchema instanceof z.ZodEffects) {
-    currentSchema = currentSchema._def.schema
+  // Handle both Zod 3 (ZodEffects with _def.schema) and Zod 4 (pipe with _def.in)
+  while (
+    currentSchema instanceof z.ZodEffects ||
+    getZodTypeIdentifier(currentSchema._def) === "pipe"
+  ) {
+    if (currentSchema instanceof z.ZodEffects) {
+      currentSchema = currentSchema._def.schema
+    } else if (currentSchema._def.in) {
+      // Zod 4 pipe structure
+      currentSchema = currentSchema._def.in
+    } else {
+      break
+    }
   }
 
   return currentSchema as z.ZodObject<any>
@@ -29,39 +62,53 @@ const getZodObjectSchemaFromZodEffectSchema = (
 
 /**
  * This function is used to get the correct schema from a ZodEffect | ZodDefault | ZodOptional schema.
- * TODO: this function should handle all special cases of ZodSchema and not just ZodEffect | ZodDefault | ZodOptional
+ * Supports both Zod 3 and Zod 4 internal structures.
  */
 const getZodDefFromZodSchemaHelpers = (schema: z.ZodTypeAny) => {
-  const special_zod_types = [
-    ZodFirstPartyTypeKind.ZodOptional,
-    ZodFirstPartyTypeKind.ZodDefault,
-    ZodFirstPartyTypeKind.ZodEffects,
-  ]
+  let currentSchema = schema as any
+  let typeId = getZodTypeIdentifier(currentSchema._def)
 
-  while (special_zod_types.includes(schema._def.typeName)) {
+  // Keep unwrapping optional, default, effects/pipe until we get to the base type
+  while (
+    isZodType(typeId, ZodFirstPartyTypeKind.ZodOptional, "optional") ||
+    isZodType(typeId, ZodFirstPartyTypeKind.ZodDefault, "default") ||
+    isZodType(typeId, ZodFirstPartyTypeKind.ZodEffects, "pipe")
+  ) {
     if (
-      schema._def.typeName === ZodFirstPartyTypeKind.ZodOptional ||
-      schema._def.typeName === ZodFirstPartyTypeKind.ZodDefault
+      isZodType(typeId, ZodFirstPartyTypeKind.ZodOptional, "optional") ||
+      isZodType(typeId, ZodFirstPartyTypeKind.ZodDefault, "default")
     ) {
-      schema = schema._def.innerType
-      continue
+      currentSchema = currentSchema._def.innerType
+    } else if (isZodType(typeId, ZodFirstPartyTypeKind.ZodEffects, "pipe")) {
+      // Zod 3 uses _def.schema, Zod 4 uses _def.in
+      currentSchema = currentSchema._def.schema ?? currentSchema._def.in
     }
 
-    if (schema._def.typeName === ZodFirstPartyTypeKind.ZodEffects) {
-      schema = schema._def.schema
-      continue
+    if (!currentSchema?._def) {
+      break
     }
+    typeId = getZodTypeIdentifier(currentSchema._def)
   }
-  return schema._def
+
+  return currentSchema._def
 }
 
 const tryGetZodSchemaAsObject = (
   schema: z.ZodTypeAny
 ): z.ZodObject<any> | undefined => {
-  const isZodEffect = schema._def.typeName === ZodFirstPartyTypeKind.ZodEffects
+  const typeId = getZodTypeIdentifier(schema._def)
+  const isZodEffect = isZodType(
+    typeId,
+    ZodFirstPartyTypeKind.ZodEffects,
+    "pipe"
+  )
   const safe_schema = getZodObjectSchemaFromZodEffectSchema(isZodEffect, schema)
-  const isZodObject =
-    safe_schema._def.typeName === ZodFirstPartyTypeKind.ZodObject
+  const safeTypeId = getZodTypeIdentifier(safe_schema._def)
+  const isZodObject = isZodType(
+    safeTypeId,
+    ZodFirstPartyTypeKind.ZodObject,
+    "object"
+  )
 
   if (!isZodObject) {
     return undefined
@@ -72,12 +119,14 @@ const tryGetZodSchemaAsObject = (
 
 const isZodSchemaArray = (schema: z.ZodTypeAny) => {
   const def = getZodDefFromZodSchemaHelpers(schema)
-  return def.typeName === ZodFirstPartyTypeKind.ZodArray
+  const typeId = getZodTypeIdentifier(def)
+  return isZodType(typeId, ZodFirstPartyTypeKind.ZodArray, "array")
 }
 
 const isZodSchemaBoolean = (schema: z.ZodTypeAny) => {
   const def = getZodDefFromZodSchemaHelpers(schema)
-  return def.typeName === ZodFirstPartyTypeKind.ZodBoolean
+  const typeId = getZodTypeIdentifier(def)
+  return isZodType(typeId, ZodFirstPartyTypeKind.ZodBoolean, "boolean")
 }
 
 const parseQueryParams = (


### PR DESCRIPTION
## Summary
- Adds Zod 4 compatibility for internal schema type detection
- Boolean query params now correctly coerce from strings in Zod 4
- Maintains backward compatibility with Zod 3

## Problem
Zod 4 changed internal schema structure:
- `_def.typeName` → `_def.type`
- `ZodFirstPartyTypeKind` enum values → lowercase string literals (e.g., `"boolean"`)
- `ZodEffects._def.schema` → pipe `_def.in`

This broke boolean query parameter coercion, causing `?details=true` to fail validation instead of being coerced to `true`.

## Solution
Added helper functions that work with both Zod 3 and Zod 4:
- `getZodTypeIdentifier()` - extracts type from either `_def.type` or `_def.typeName`
- `isZodType()` - checks against both Zod 3 enum and Zod 4 string

Type mappings supported:
| Zod 3 | Zod 4 |
|-------|-------|
| `ZodFirstPartyTypeKind.ZodOptional` | `"optional"` |
| `ZodFirstPartyTypeKind.ZodDefault` | `"default"` |
| `ZodFirstPartyTypeKind.ZodEffects` | `"pipe"` |
| `ZodFirstPartyTypeKind.ZodObject` | `"object"` |
| `ZodFirstPartyTypeKind.ZodArray` | `"array"` |
| `ZodFirstPartyTypeKind.ZodBoolean` | `"boolean"` |

## Test plan
- [x] All 166 existing tests pass
- [x] TypeScript type checking passes
- [ ] Manual testing with Zod 4 in seam-connect project

🤖 Generated with [Claude Code](https://claude.ai/code)